### PR TITLE
[FEATURE] 공고, 지원 테이블 설계 및 엔티티 구현

### DIFF
--- a/core-domain/src/main/java/gohigher/recruitment/RecruitmentType.java
+++ b/core-domain/src/main/java/gohigher/recruitment/RecruitmentType.java
@@ -1,4 +1,4 @@
-package gohigher.entity.recruitment;
+package gohigher.recruitment;
 
 public enum RecruitmentType {
 	PUBLIC,

--- a/in-adapter-api/build.gradle
+++ b/in-adapter-api/build.gradle
@@ -11,6 +11,8 @@ repositories {
 
 dependencies {
     implementation(project(":core-application"))
+    implementation(project(":core-domain"))
+    implementation(project(":out-adapter-persistence-jpa"))
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/out-adapter-persistence-jpa/build.gradle
+++ b/out-adapter-persistence-jpa/build.gradle
@@ -10,10 +10,11 @@ repositories {
 }
 
 dependencies {
+    implementation(project(":core-domain"))
     implementation(project(":core-application"))
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation("org.springframework:spring-context")
+    implementation 'org.springframework:spring-context'
 
     runtimeOnly 'mysql:mysql-connector-java:8.0.33'
 }

--- a/out-adapter-persistence-jpa/src/main/java/gohigher/entity/application/ApplicationJpaEntity.java
+++ b/out-adapter-persistence-jpa/src/main/java/gohigher/entity/application/ApplicationJpaEntity.java
@@ -1,0 +1,35 @@
+package gohigher.entity.application;
+
+import gohigher.entity.recruitment.RecruitmentJpaEntity;
+import gohigher.recruitment.ProcessType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class ApplicationJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recruitment_id")
+    private RecruitmentJpaEntity recruitment;
+
+    @Enumerated(EnumType.STRING)
+    private ProcessType currentProcess;
+}

--- a/out-adapter-persistence-jpa/src/main/java/gohigher/entity/application/ApplicationJpaEntity.java
+++ b/out-adapter-persistence-jpa/src/main/java/gohigher/entity/application/ApplicationJpaEntity.java
@@ -11,12 +11,14 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "application")
 @Entity
 public class ApplicationJpaEntity {
 

--- a/out-adapter-persistence-jpa/src/main/java/gohigher/entity/application/ApplicationJpaEntity.java
+++ b/out-adapter-persistence-jpa/src/main/java/gohigher/entity/application/ApplicationJpaEntity.java
@@ -22,16 +22,16 @@ import lombok.NoArgsConstructor;
 @Entity
 public class ApplicationJpaEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-    private Long userId;
+	private Long userId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "recruitment_id")
-    private RecruitmentJpaEntity recruitment;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "recruitment_id")
+	private RecruitmentJpaEntity recruitment;
 
-    @Enumerated(EnumType.STRING)
-    private ProcessType currentProcess;
+	@Enumerated(EnumType.STRING)
+	private ProcessType currentProcess;
 }

--- a/out-adapter-persistence-jpa/src/main/java/gohigher/entity/application/ApplicationRepository.java
+++ b/out-adapter-persistence-jpa/src/main/java/gohigher/entity/application/ApplicationRepository.java
@@ -1,0 +1,6 @@
+package gohigher.entity.application;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ApplicationRepository extends JpaRepository<ApplicationJpaEntity, Long> {
+}

--- a/out-adapter-persistence-jpa/src/main/java/gohigher/entity/recruitment/RecruitmentDetailJpaEntity.java
+++ b/out-adapter-persistence-jpa/src/main/java/gohigher/entity/recruitment/RecruitmentDetailJpaEntity.java
@@ -3,7 +3,6 @@ package gohigher.entity.recruitment;
 import java.time.LocalDateTime;
 
 import gohigher.recruitment.EmploymentType;
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -33,7 +32,6 @@ public class RecruitmentDetailJpaEntity {
 	private String workType;
 
 	@Enumerated(value = EnumType.STRING)
-	@Column(updatable = false)
 	private EmploymentType employmentType;
 	private String careerRequirement;
 	private String requiredCapability;

--- a/out-adapter-persistence-jpa/src/main/java/gohigher/entity/recruitment/RecruitmentDetailJpaEntity.java
+++ b/out-adapter-persistence-jpa/src/main/java/gohigher/entity/recruitment/RecruitmentDetailJpaEntity.java
@@ -21,24 +21,24 @@ import lombok.NoArgsConstructor;
 @Entity
 public class RecruitmentDetailJpaEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-    private String companyName;
-    private String location;
-    private String contact;
-    private String duty;
-    private String jobDescription;
-    private String workType;
+	private String companyName;
+	private String location;
+	private String contact;
+	private String duty;
+	private String jobDescription;
+	private String workType;
 
-    @Enumerated(value = EnumType.STRING)
-    @Column(updatable = false)
-    private EmploymentType employmentType;
-    private String careerRequirement;
-    private String requiredCapability;
-    private String preferredQualification;
-    private LocalDateTime deadline;
-    private String url;
-    private boolean isDeleted;
+	@Enumerated(value = EnumType.STRING)
+	@Column(updatable = false)
+	private EmploymentType employmentType;
+	private String careerRequirement;
+	private String requiredCapability;
+	private String preferredQualification;
+	private LocalDateTime deadline;
+	private String url;
+	private boolean isDeleted;
 }

--- a/out-adapter-persistence-jpa/src/main/java/gohigher/entity/recruitment/RecruitmentDetailJpaEntity.java
+++ b/out-adapter-persistence-jpa/src/main/java/gohigher/entity/recruitment/RecruitmentDetailJpaEntity.java
@@ -10,12 +10,14 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "recruitment_detail")
 @Entity
 public class RecruitmentDetailJpaEntity {
 
@@ -36,7 +38,7 @@ public class RecruitmentDetailJpaEntity {
     private String careerRequirement;
     private String requiredCapability;
     private String preferredQualification;
-    private LocalDateTime deadLine;
+    private LocalDateTime deadline;
     private String url;
     private boolean isDeleted;
 }

--- a/out-adapter-persistence-jpa/src/main/java/gohigher/entity/recruitment/RecruitmentDetailJpaEntity.java
+++ b/out-adapter-persistence-jpa/src/main/java/gohigher/entity/recruitment/RecruitmentDetailJpaEntity.java
@@ -1,0 +1,42 @@
+package gohigher.entity.recruitment;
+
+import java.time.LocalDateTime;
+
+import gohigher.recruitment.EmploymentType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class RecruitmentDetailJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String companyName;
+    private String location;
+    private String contact;
+    private String duty;
+    private String jobDescription;
+    private String workType;
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(updatable = false)
+    private EmploymentType employmentType;
+    private String careerRequirement;
+    private String requiredCapability;
+    private String preferredQualification;
+    private LocalDateTime deadLine;
+    private String url;
+    private boolean isDeleted;
+}

--- a/out-adapter-persistence-jpa/src/main/java/gohigher/entity/recruitment/RecruitmentDetailRepository.java
+++ b/out-adapter-persistence-jpa/src/main/java/gohigher/entity/recruitment/RecruitmentDetailRepository.java
@@ -1,0 +1,6 @@
+package gohigher.entity.recruitment;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RecruitmentDetailRepository extends JpaRepository<RecruitmentDetailJpaEntity, Long> {
+}

--- a/out-adapter-persistence-jpa/src/main/java/gohigher/entity/recruitment/RecruitmentJpaEntity.java
+++ b/out-adapter-persistence-jpa/src/main/java/gohigher/entity/recruitment/RecruitmentJpaEntity.java
@@ -1,0 +1,31 @@
+package gohigher.entity.recruitment;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class RecruitmentJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recruitment_detail_id")
+    private RecruitmentDetailJpaEntity recruitmentDetail;
+
+    @Enumerated(value = EnumType.STRING)
+    private RecruitmentType type;
+}

--- a/out-adapter-persistence-jpa/src/main/java/gohigher/entity/recruitment/RecruitmentJpaEntity.java
+++ b/out-adapter-persistence-jpa/src/main/java/gohigher/entity/recruitment/RecruitmentJpaEntity.java
@@ -20,14 +20,14 @@ import lombok.NoArgsConstructor;
 @Entity
 public class RecruitmentJpaEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "recruitment_detail_id")
-    private RecruitmentDetailJpaEntity recruitmentDetail;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "recruitment_detail_id")
+	private RecruitmentDetailJpaEntity recruitmentDetail;
 
-    @Enumerated(value = EnumType.STRING)
-    private RecruitmentType type;
+	@Enumerated(value = EnumType.STRING)
+	private RecruitmentType type;
 }

--- a/out-adapter-persistence-jpa/src/main/java/gohigher/entity/recruitment/RecruitmentJpaEntity.java
+++ b/out-adapter-persistence-jpa/src/main/java/gohigher/entity/recruitment/RecruitmentJpaEntity.java
@@ -9,12 +9,14 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "recruitment")
 @Entity
 public class RecruitmentJpaEntity {
 

--- a/out-adapter-persistence-jpa/src/main/java/gohigher/entity/recruitment/RecruitmentJpaEntity.java
+++ b/out-adapter-persistence-jpa/src/main/java/gohigher/entity/recruitment/RecruitmentJpaEntity.java
@@ -1,5 +1,6 @@
 package gohigher.entity.recruitment;
 
+import gohigher.recruitment.RecruitmentType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;

--- a/out-adapter-persistence-jpa/src/main/java/gohigher/entity/recruitment/RecruitmentJpaEntity.java
+++ b/out-adapter-persistence-jpa/src/main/java/gohigher/entity/recruitment/RecruitmentJpaEntity.java
@@ -1,6 +1,7 @@
 package gohigher.entity.recruitment;
 
 import gohigher.recruitment.RecruitmentType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -30,5 +31,6 @@ public class RecruitmentJpaEntity {
 	private RecruitmentDetailJpaEntity recruitmentDetail;
 
 	@Enumerated(value = EnumType.STRING)
+	@Column(updatable = false)
 	private RecruitmentType type;
 }

--- a/out-adapter-persistence-jpa/src/main/java/gohigher/entity/recruitment/RecruitmentProcessJpaEntity.java
+++ b/out-adapter-persistence-jpa/src/main/java/gohigher/entity/recruitment/RecruitmentProcessJpaEntity.java
@@ -24,17 +24,17 @@ import lombok.NoArgsConstructor;
 @Entity
 public class RecruitmentProcessJpaEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "recruitment_id", nullable = false)
-    private RecruitmentJpaEntity recruitment;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "recruitment_id", nullable = false)
+	private RecruitmentJpaEntity recruitment;
 
-    @Column(nullable = false)
-    @Enumerated(value = EnumType.STRING)
-    private ProcessType type;
+	@Column(nullable = false)
+	@Enumerated(value = EnumType.STRING)
+	private ProcessType type;
 
-    private LocalDateTime schedule;
+	private LocalDateTime schedule;
 }

--- a/out-adapter-persistence-jpa/src/main/java/gohigher/entity/recruitment/RecruitmentProcessJpaEntity.java
+++ b/out-adapter-persistence-jpa/src/main/java/gohigher/entity/recruitment/RecruitmentProcessJpaEntity.java
@@ -13,12 +13,14 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "recruitment_process")
 @Entity
 public class RecruitmentProcessJpaEntity {
 

--- a/out-adapter-persistence-jpa/src/main/java/gohigher/entity/recruitment/RecruitmentProcessJpaEntity.java
+++ b/out-adapter-persistence-jpa/src/main/java/gohigher/entity/recruitment/RecruitmentProcessJpaEntity.java
@@ -1,0 +1,38 @@
+package gohigher.entity.recruitment;
+
+import java.time.LocalDateTime;
+
+import gohigher.recruitment.ProcessType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class RecruitmentProcessJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recruitment_id", nullable = false)
+    private RecruitmentJpaEntity recruitment;
+
+    @Column(nullable = false)
+    @Enumerated(value = EnumType.STRING)
+    private ProcessType type;
+
+    private LocalDateTime schedule;
+}

--- a/out-adapter-persistence-jpa/src/main/java/gohigher/entity/recruitment/RecruitmentProcessRepository.java
+++ b/out-adapter-persistence-jpa/src/main/java/gohigher/entity/recruitment/RecruitmentProcessRepository.java
@@ -1,0 +1,6 @@
+package gohigher.entity.recruitment;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RecruitmentProcessRepository extends JpaRepository<RecruitmentProcessJpaEntity, Long> {
+}

--- a/out-adapter-persistence-jpa/src/main/java/gohigher/entity/recruitment/RecruitmentRepository.java
+++ b/out-adapter-persistence-jpa/src/main/java/gohigher/entity/recruitment/RecruitmentRepository.java
@@ -1,0 +1,6 @@
+package gohigher.entity.recruitment;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RecruitmentRepository extends JpaRepository<RecruitmentJpaEntity, Long> {
+}

--- a/out-adapter-persistence-jpa/src/main/java/gohigher/entity/recruitment/RecruitmentType.java
+++ b/out-adapter-persistence-jpa/src/main/java/gohigher/entity/recruitment/RecruitmentType.java
@@ -3,5 +3,4 @@ package gohigher.entity.recruitment;
 public enum RecruitmentType {
     PUBLIC,
     PRIVATE,
-    ;
 }

--- a/out-adapter-persistence-jpa/src/main/java/gohigher/entity/recruitment/RecruitmentType.java
+++ b/out-adapter-persistence-jpa/src/main/java/gohigher/entity/recruitment/RecruitmentType.java
@@ -1,0 +1,7 @@
+package gohigher.entity.recruitment;
+
+public enum RecruitmentType {
+    PUBLIC,
+    PRIVATE,
+    ;
+}

--- a/out-adapter-persistence-jpa/src/main/java/gohigher/entity/recruitment/RecruitmentType.java
+++ b/out-adapter-persistence-jpa/src/main/java/gohigher/entity/recruitment/RecruitmentType.java
@@ -1,6 +1,6 @@
 package gohigher.entity.recruitment;
 
 public enum RecruitmentType {
-    PUBLIC,
-    PRIVATE,
+	PUBLIC,
+	PRIVATE,
 }

--- a/out-adapter-persistence-jpa/src/main/resources/application-local.yml
+++ b/out-adapter-persistence-jpa/src/main/resources/application-local.yml
@@ -1,0 +1,13 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: root
+    password: password
+    url: jdbc:mysql://localhost:3306/gohigher?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+  jpa:
+    hibernate.ddl-auto: create
+    database-platform: org.hibernate.dialect.MySQLDialect
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true


### PR DESCRIPTION
## ⭐️ 작업 내용
현재 아래의 테이블 구조로 엔티티 구현을 완료 하였습니다. 

<img width="779" alt="image" src="https://github.com/team-go-higher/backend/assets/57744251/76d95f42-c6d6-4510-8d86-f49c7f6c9489">

## 🧐 논의하면 좋을 내용
- 백엔드 회의를 하며 테이블간 객체 참조가 아닌 id 참조로 진행하자했는데 조회, 생성 로직 등 공고와 지원서 관련 모든 로직들이 `recruitment`, `recruitment_detail` 테이블과 함께 동작할 것으로 생각되어 객체 참조로 작성했습니다. id참조로 진행하는 것이 좋을 것 같다면 수정하겠습니다.
- db관련한 연결 정보는 현재 서브모듈이 구축되어있지 않고 로컬 db를 연결한 상태라 yml파일 자체를 업로드하였습니다. 추후 서브모듈과 같이 암호화 데이터를 관리하는 체계가 만들어지면 그때 이동시키면 될 것 같습니다.
- Flyway 또한 별도의 이슈를 만들어서 추가하면 좋을 것 같습니다.