### PR TITLE
[FEATURE] CORS 설정

### DIFF
--- a/bootstrap/src/main/resources/application.yml
+++ b/bootstrap/src/main/resources/application.yml
@@ -7,6 +7,7 @@ spring:
       - auth/application.yml
       - jwt/application.yml
       - persistence/application.yml
+      - cors/application.yml
 
 jasypt:
   encryptor:

--- a/in-adapter-api/src/main/java/gohigher/config/AuthConfig.java
+++ b/in-adapter-api/src/main/java/gohigher/config/AuthConfig.java
@@ -13,6 +13,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class AuthConfig implements WebMvcConfigurer {
 
 	private static final String ALLOWED_METHOD_NAMES = "GET,HEAD,POST,PUT,DELETE,TRACE,OPTIONS,PATCH";
+	private static final String SPLIT_REGEX = ",";
 
 	private final List<HandlerMethodArgumentResolver> resolvers;
 	private final String[] allowedOrigin;
@@ -29,7 +30,7 @@ public class AuthConfig implements WebMvcConfigurer {
 	public void addCorsMappings(CorsRegistry registry) {
 		registry.addMapping("/**")
 			.allowedOrigins(allowedOrigin)
-			.allowedMethods(ALLOWED_METHOD_NAMES.split(","))
+			.allowedMethods(ALLOWED_METHOD_NAMES.split(SPLIT_REGEX))
 			.allowCredentials(true)
 			.exposedHeaders(HttpHeaders.LOCATION);
 	}

--- a/in-adapter-api/src/main/java/gohigher/config/AuthConfig.java
+++ b/in-adapter-api/src/main/java/gohigher/config/AuthConfig.java
@@ -2,17 +2,37 @@ package gohigher.config;
 
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-import lombok.RequiredArgsConstructor;
-
 @Configuration
-@RequiredArgsConstructor
 public class AuthConfig implements WebMvcConfigurer {
 
+	private static final String ALLOWED_METHOD_NAMES = "GET,HEAD,POST,PUT,DELETE,TRACE,OPTIONS,PATCH";
+
 	private final List<HandlerMethodArgumentResolver> resolvers;
+	private final String[] allowedOrigin;
+
+	public AuthConfig(List<HandlerMethodArgumentResolver> resolvers,
+		@Value("${cors-config.allowed-origin}") String allowedOrigin,
+		@Value("${cors-config.local-origin}") String localOrigin) {
+		this.resolvers = resolvers;
+		this.allowedOrigin = new String[] {allowedOrigin, localOrigin};
+
+	}
+
+	@Override
+	public void addCorsMappings(CorsRegistry registry) {
+		registry.addMapping("/**")
+			.allowedOrigins(allowedOrigin)
+			.allowedMethods(ALLOWED_METHOD_NAMES.split(","))
+			.allowCredentials(true)
+			.exposedHeaders(HttpHeaders.LOCATION);
+	}
 
 	@Override
 	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {

--- a/in-adapter-api/src/main/resources/cors/application.yml
+++ b/in-adapter-api/src/main/resources/cors/application.yml
@@ -1,0 +1,3 @@
+cors-config:
+  local-origin: 'http://localhost:3000'
+  allowed-origin: 'https://dev.dprz5tkaxr2l9.amplifyapp.com'

--- a/in-adapter-api/src/main/resources/cors/application.yml
+++ b/in-adapter-api/src/main/resources/cors/application.yml
@@ -1,3 +1,3 @@
 cors-config:
   local-origin: 'http://localhost:3000'
-  allowed-origin: 'https://dev.dprz5tkaxr2l9.amplifyapp.com'
+  allowed-origin: 'https://dev.gohigher.site'

--- a/security/src/main/java/gohigher/config/SpringSecurityConfig.java
+++ b/security/src/main/java/gohigher/config/SpringSecurityConfig.java
@@ -7,7 +7,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configurers.CorsConfigurer;
 import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
@@ -46,7 +45,6 @@ public class SpringSecurityConfig {
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 		http.csrf(CsrfConfigurer::disable)
-			.cors(CorsConfigurer::disable)
 			.sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 			.authorizeHttpRequests(auth ->
 				auth.requestMatchers(tokenRequestUri + "/**", "/api-docs", "/swagger-ui/**",

--- a/security/src/main/resources/auth/application-dev.yml
+++ b/security/src/main/resources/auth/application-dev.yml
@@ -10,4 +10,4 @@ spring:
 
 oauth2:
   success:
-    redirect_uri: 'https://dev.dprz5tkaxr2l9.amplifyapp.com'
+    redirect_uri: 'https://dev.gohigher.site'


### PR DESCRIPTION
## 작업 내용
- CORS를 설정한다.

## 주요 사항
고하이어의 경우 Spring Security를 타는 api와 타지 않는 api가 있어 cors 설정을 `in-adapter-api`, `security` 두 군데서 해줘야 할 줄 알았습니다. 그러나 공식 문서를 찾아보니 다음과 같이 나와있었습니다.

<img width="970" alt="스크린샷 2023-09-13 오전 12 29 20" src="https://github.com/team-go-higher/backend/assets/70707629/745c9c70-50e5-4af4-b013-97a7970f0cb4">

따라서 `in-adapter-api` 모듈의 AuthConfig에 cors를 설정하였습니다.

resolve #65 
