### PR TITLE
[FEATURE] 직무 목록 전체 조회 API 구현

### DIFF
--- a/core-application/src/main/java/gohigher/application/port/in/ApplicationResponse.java
+++ b/core-application/src/main/java/gohigher/application/port/in/ApplicationResponse.java
@@ -16,8 +16,8 @@ public class ApplicationResponse {
 	private final String team;
 	private final String location;
 	private final String contact;
-	private final String duty;
 	private final String position;
+	private final String specificPosition;
 	private final String jobDescription;
 	private final String workType;
 	private final String employmentType;
@@ -42,8 +42,8 @@ public class ApplicationResponse {
 			application.getTeam(),
 			application.getLocation(),
 			application.getContact(),
-			application.getDuty(),
 			application.getPosition(),
+			application.getSpecificPosition(),
 			application.getJobDescription(),
 			application.getWorkType(),
 			application.getEmploymentType().name(),

--- a/core-application/src/main/java/gohigher/application/port/in/SimpleApplicationRequest.java
+++ b/core-application/src/main/java/gohigher/application/port/in/SimpleApplicationRequest.java
@@ -13,13 +13,13 @@ public class SimpleApplicationRequest {
 	private String companyName;
 
 	@NotBlank(message = "JOB_INFO_003||직무가 입력되지 않았습니다.")
-	private String duty;
+	private String position;
 
 	private String url;
 
 	private SimpleApplicationProcessRequest currentProcess;
 
 	public Application toDomain() {
-		return Application.simple(companyName, duty, url, currentProcess.toDomain());
+		return Application.simple(companyName, position, url, currentProcess.toDomain());
 	}
 }

--- a/core-application/src/main/java/gohigher/application/port/in/SpecificApplicationRequest.java
+++ b/core-application/src/main/java/gohigher/application/port/in/SpecificApplicationRequest.java
@@ -16,8 +16,8 @@ public class SpecificApplicationRequest {
 	private String team;
 	private String location;
 	private String contact;
-	private String duty;
 	private String position;
+	private String specificPosition;
 	private String jobDescription;
 	private String workType;
 	private String employmentType;
@@ -31,7 +31,7 @@ public class SpecificApplicationRequest {
 		List<Process> processes = this.processes.stream()
 			.map(SpecificApplicationProcessRequest::toDomain)
 			.toList();
-		return new Application(null, companyName, team, location, contact, duty, position, jobDescription, workType,
+		return new Application(null, companyName, team, location, contact, position, specificPosition, jobDescription, workType,
 			EmploymentType.from(employmentType), careerRequirement, requiredCapability, preferredQualification,
 			processes, url, processes.get(0));
 	}

--- a/core-application/src/main/java/gohigher/position/port/in/PositionQueryPort.java
+++ b/core-application/src/main/java/gohigher/position/port/in/PositionQueryPort.java
@@ -1,0 +1,8 @@
+package gohigher.position.port.in;
+
+import java.util.List;
+
+public interface PositionQueryPort {
+
+	List<PositionResponse> findPositions();
+}

--- a/core-application/src/main/java/gohigher/position/port/in/PositionResponse.java
+++ b/core-application/src/main/java/gohigher/position/port/in/PositionResponse.java
@@ -1,0 +1,12 @@
+package gohigher.position.port.in;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class PositionResponse {
+
+	private final Long id;
+	private final String position;
+}

--- a/core-application/src/main/java/gohigher/position/port/in/PositionResponse.java
+++ b/core-application/src/main/java/gohigher/position/port/in/PositionResponse.java
@@ -1,5 +1,6 @@
 package gohigher.position.port.in;
 
+import gohigher.position.Position;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -9,4 +10,8 @@ public class PositionResponse {
 
 	private final Long id;
 	private final String position;
+
+	public static PositionResponse from(Position position) {
+		return new PositionResponse(position.getId(), position.getValue());
+	}
 }

--- a/core-application/src/main/java/gohigher/position/port/out/PositionPersistenceQueryPort.java
+++ b/core-application/src/main/java/gohigher/position/port/out/PositionPersistenceQueryPort.java
@@ -1,0 +1,10 @@
+package gohigher.position.port.out;
+
+import java.util.List;
+
+import gohigher.position.Position;
+
+public interface PositionPersistenceQueryPort {
+
+	List<Position> findAll();
+}

--- a/core-application/src/main/java/gohigher/position/service/PositionQueryService.java
+++ b/core-application/src/main/java/gohigher/position/service/PositionQueryService.java
@@ -1,0 +1,28 @@
+package gohigher.position.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import gohigher.position.port.in.PositionQueryPort;
+import gohigher.position.port.in.PositionResponse;
+import gohigher.position.port.out.PositionPersistenceQueryPort;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PositionQueryService implements PositionQueryPort {
+
+	private final PositionPersistenceQueryPort positionPersistenceQueryPort;
+
+	@Override
+	public List<PositionResponse> findPositions() {
+		return positionPersistenceQueryPort.findAll()
+			.stream()
+			.map(PositionResponse::from)
+			.toList();
+	}
+}

--- a/core-domain/src/main/java/gohigher/application/Application.java
+++ b/core-domain/src/main/java/gohigher/application/Application.java
@@ -15,17 +15,17 @@ public class Application extends JobInfo {
 
 	private final Process currentProcess;
 
-	public Application(Long id, String companyName, String team, String location, String contact, String duty,
-		String position, String jobDescription, String workType, EmploymentType employmentType,
+	public Application(Long id, String companyName, String team, String location, String contact, String position,
+		String specificPosition, String jobDescription, String workType, EmploymentType employmentType,
 		String careerRequirement, String requiredCapability, String preferredQualification, List<Process> processes,
 		String url, Process currentProcess) {
-		super(id, companyName, team, location, contact, duty, position, jobDescription, workType, employmentType,
-			careerRequirement, requiredCapability, preferredQualification, processes, url);
+		super(id, companyName, team, location, contact, position, specificPosition, jobDescription, workType,
+			employmentType, careerRequirement, requiredCapability, preferredQualification, processes, url);
 		this.currentProcess = currentProcess;
 	}
 
-	public static Application simple(String companyName, String duty, String url, Process process) {
-		return new Application(null, companyName, null, null, null, duty, null, null,
+	public static Application simple(String companyName, String position, String url, Process process) {
+		return new Application(null, companyName, null, null, null, position, null, null,
 			null, null, null, null, null, List.of(process), url, process);
 	}
 }

--- a/core-domain/src/main/java/gohigher/common/JobInfo.java
+++ b/core-domain/src/main/java/gohigher/common/JobInfo.java
@@ -9,8 +9,8 @@ import lombok.RequiredArgsConstructor;
  * id					  데이터 id
  * companyName            회사명
  * team					  부서
- * duty                   직무
- * position				  포지션
+ * position               직무
+ * specificPosition		  세부직무
  * processes              전형 단계
  * jobDescription         주요 업무
  * requiredCapability     필수 역량
@@ -31,8 +31,8 @@ public abstract class JobInfo {
 	protected final String team;
 	protected final String location;
 	protected final String contact;
-	protected final String duty;
 	protected final String position;
+	protected final String specificPosition;
 	protected final String jobDescription;
 	protected final String workType;
 	protected final EmploymentType employmentType;

--- a/core-domain/src/main/java/gohigher/common/JobInfoErrorCode.java
+++ b/core-domain/src/main/java/gohigher/common/JobInfoErrorCode.java
@@ -10,7 +10,7 @@ public enum JobInfoErrorCode implements ErrorCode {
 
 	INVALID_PROCESS_TYPE(400, "JOB_INFO_001", "유효하지 않은 전형 단계입니다."),
 	COMPANY_NAME_BLANK(400, "JOB_INFO_002", "회사명이 입력되지 않았습니다."),
-	DUTY_BLANK(400, "JOB_INFO_003", "직무가 입력되지 않았습니다."),
+	POSITION_BLANK(400, "JOB_INFO_003", "직무가 입력되지 않았습니다."),
 	INVALID_EMPLOYMENT_TYPE(400, "JOB_INFO_004", "유효하지 않은 고용 형태입니다."),
 	PROCESS_TYPE_BLANK(400, "JOB_INFO_005", "전형 단계가 입력되지 않았습니다."),
 	PROCESS_DESCRIPTION_BLANK(400, "JOB_INFO_006", "세부 전형이 입력되지 않았습니다."),

--- a/core-domain/src/main/java/gohigher/position/Position.java
+++ b/core-domain/src/main/java/gohigher/position/Position.java
@@ -9,6 +9,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class Position {
 
+	private final Long id;
 	private final String value;
-	private final List<SpecificPosition> specificPositions;
 }

--- a/core-domain/src/main/java/gohigher/position/Position.java
+++ b/core-domain/src/main/java/gohigher/position/Position.java
@@ -1,7 +1,5 @@
 package gohigher.position;
 
-import java.util.List;
-
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 

--- a/core-domain/src/main/java/gohigher/position/Position.java
+++ b/core-domain/src/main/java/gohigher/position/Position.java
@@ -1,0 +1,14 @@
+package gohigher.position;
+
+import java.util.List;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class Position {
+
+	private final String value;
+	private final List<SpecificPosition> specificPositions;
+}

--- a/core-domain/src/main/java/gohigher/recruitment/Recruitment.java
+++ b/core-domain/src/main/java/gohigher/recruitment/Recruitment.java
@@ -8,11 +8,11 @@ import gohigher.common.Process;
 
 public class Recruitment extends JobInfo {
 
-	public Recruitment(Long id, String companyName, String team, String location, String contact, String duty,
-		String position, String jobDescription, String workType, EmploymentType employmentType,
+	public Recruitment(Long id, String companyName, String team, String location, String contact, String position,
+		String specificPosition, String jobDescription, String workType, EmploymentType employmentType,
 		String careerRequirement, String requiredCapability, String preferredQualification, List<Process> processes,
 		String url) {
-		super(id, companyName, team, location, contact, duty, position, jobDescription, workType, employmentType,
+		super(id, companyName, team, location, contact, position, specificPosition, jobDescription, workType, employmentType,
 			careerRequirement, requiredCapability, preferredQualification, processes, url);
 	}
 }

--- a/core-domain/src/testFixtures/java/gohigher/application/ApplicationFixture.java
+++ b/core-domain/src/testFixtures/java/gohigher/application/ApplicationFixture.java
@@ -27,8 +27,8 @@ public enum ApplicationFixture {
 	private final String team;
 	private final String location;
 	private final String contact;
-	private final String duty;
 	private final String position;
+	private final String specificPosition;
 	private final String jobDescription;
 	private final String workType;
 	private final EmploymentType employmentType;
@@ -56,8 +56,8 @@ public enum ApplicationFixture {
 		private String team;
 		private String location;
 		private String contact;
-		private String duty;
 		private String position;
+		private String specificPosition;
 		private String jobDescription;
 		private String workType;
 		private EmploymentType employmentType;
@@ -73,8 +73,8 @@ public enum ApplicationFixture {
 			this.team = application.getTeam();
 			this.location = application.getLocation();
 			this.contact = application.getContact();
-			this.duty = application.getDuty();
 			this.position = application.getPosition();
+			this.specificPosition = application.getSpecificPosition();
 			this.jobDescription = application.getJobDescription();
 			this.workType = application.getWorkType();
 			this.employmentType = application.getEmploymentType();
@@ -97,7 +97,7 @@ public enum ApplicationFixture {
 		}
 
 		public Application toDomain() {
-			return new Application(null, companyName, team, location, contact, duty, position, jobDescription, workType,
+			return new Application(null, companyName, team, location, contact, position, specificPosition, jobDescription, workType,
 				employmentType, careerRequirement, requiredCapability, preferredQualification, processes, url,
 				currentProcess);
 		}

--- a/in-adapter-api/src/main/java/gohigher/position/PositionQueryController.java
+++ b/in-adapter-api/src/main/java/gohigher/position/PositionQueryController.java
@@ -13,7 +13,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-public class PositionQueryController {
+public class PositionQueryController implements PositionQueryControllerDocs {
 
 	private final PositionQueryPort positionQueryPort;
 

--- a/in-adapter-api/src/main/java/gohigher/position/PositionQueryController.java
+++ b/in-adapter-api/src/main/java/gohigher/position/PositionQueryController.java
@@ -18,7 +18,7 @@ public class PositionQueryController implements PositionQueryControllerDocs {
 	private final PositionQueryPort positionQueryPort;
 
 	@GetMapping("/v1/positions")
-	public ResponseEntity<GohigherResponse<List<PositionResponse>>> getPositions() {
+	public ResponseEntity<GohigherResponse<List<PositionResponse>>> findPositions() {
 		List<PositionResponse> response = positionQueryPort.findPositions();
 		return ResponseEntity.ok(GohigherResponse.success(response));
 	}

--- a/in-adapter-api/src/main/java/gohigher/position/PositionQueryController.java
+++ b/in-adapter-api/src/main/java/gohigher/position/PositionQueryController.java
@@ -1,0 +1,25 @@
+package gohigher.position;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import gohigher.controller.response.GohigherResponse;
+import gohigher.position.port.in.PositionQueryPort;
+import gohigher.position.port.in.PositionResponse;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class PositionQueryController {
+
+	private final PositionQueryPort positionQueryPort;
+
+	@GetMapping("/v1/positions")
+	public ResponseEntity<GohigherResponse<List<PositionResponse>>> getPositions() {
+		List<PositionResponse> response = positionQueryPort.findPositions();
+		return ResponseEntity.ok(GohigherResponse.success(response));
+	}
+}

--- a/in-adapter-api/src/main/java/gohigher/position/PositionQueryControllerDocs.java
+++ b/in-adapter-api/src/main/java/gohigher/position/PositionQueryControllerDocs.java
@@ -1,0 +1,19 @@
+package gohigher.position;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+
+import gohigher.controller.response.GohigherResponse;
+import gohigher.position.port.in.PositionResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "직무")
+public interface PositionQueryControllerDocs {
+
+	@Operation(summary = "직무 전체 조회")
+	@ApiResponse(responseCode = "200", description = "조회 성공")
+	ResponseEntity<GohigherResponse<List<PositionResponse>>> getPositions();
+}

--- a/in-adapter-api/src/main/java/gohigher/position/PositionQueryControllerDocs.java
+++ b/in-adapter-api/src/main/java/gohigher/position/PositionQueryControllerDocs.java
@@ -15,5 +15,5 @@ public interface PositionQueryControllerDocs {
 
 	@Operation(summary = "직무 전체 조회")
 	@ApiResponse(responseCode = "200", description = "조회 성공")
-	ResponseEntity<GohigherResponse<List<PositionResponse>>> getPositions();
+	ResponseEntity<GohigherResponse<List<PositionResponse>>> findPositions();
 }

--- a/out-adapter-persistence-jpa/src/main/java/gohigher/application/entity/ApplicationJpaEntity.java
+++ b/out-adapter-persistence-jpa/src/main/java/gohigher/application/entity/ApplicationJpaEntity.java
@@ -41,8 +41,8 @@ public class ApplicationJpaEntity {
 	private String team;
 	private String location;
 	private String contact;
-	private String duty;
 	private String position;
+	private String specificPosition;
 	private String jobDescription;
 	private String workType;
 
@@ -70,8 +70,8 @@ public class ApplicationJpaEntity {
 			application.getTeam(),
 			application.getLocation(),
 			application.getContact(),
-			application.getDuty(),
 			application.getPosition(),
+			application.getSpecificPosition(),
 			application.getJobDescription(),
 			application.getWorkType(),
 			application.getEmploymentType(),
@@ -105,12 +105,12 @@ public class ApplicationJpaEntity {
 			.toList();
 
 		if (currentProcessOrder == 0) {
-			return new Application(id, companyName, team, location, contact, duty, position, jobDescription, workType,
+			return new Application(id, companyName, team, location, contact, position, specificPosition, jobDescription, workType,
 				employmentType, careerRequirement, requiredCapability, preferredQualification, processes, url,
 				null);
 		}
 
-		return new Application(id, companyName, team, location, contact, duty, position, jobDescription, workType,
+		return new Application(id, companyName, team, location, contact, position, specificPosition, jobDescription, workType,
 			employmentType, careerRequirement, requiredCapability, preferredQualification, processes, url,
 			processes.get(currentProcessOrder));
 	}
@@ -121,7 +121,7 @@ public class ApplicationJpaEntity {
 			.map(ApplicationProcessJpaEntity::toDomain)
 			.toList();
 
-		return new Application(id, companyName, team, location, contact, duty, position, jobDescription, workType,
+		return new Application(id, companyName, team, location, contact, position, specificPosition, jobDescription, workType,
 			employmentType, careerRequirement, requiredCapability, preferredQualification, processes, url,
 			null);
 	}

--- a/out-adapter-persistence-jpa/src/main/java/gohigher/position/entity/PositionJpaEntity.java
+++ b/out-adapter-persistence-jpa/src/main/java/gohigher/position/entity/PositionJpaEntity.java
@@ -1,0 +1,23 @@
+package gohigher.position.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "position")
+@Entity
+public class PositionJpaEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private String position;
+}

--- a/out-adapter-persistence-jpa/src/main/java/gohigher/position/entity/PositionJpaEntity.java
+++ b/out-adapter-persistence-jpa/src/main/java/gohigher/position/entity/PositionJpaEntity.java
@@ -1,5 +1,6 @@
 package gohigher.position.entity;
 
+import gohigher.position.Position;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -20,4 +21,8 @@ public class PositionJpaEntity {
 	private Long id;
 
 	private String position;
+
+	public Position toDomain() {
+		return new Position(id, position);
+	}
 }

--- a/out-adapter-persistence-jpa/src/main/java/gohigher/position/entity/PositionPersistenceQueryAdapter.java
+++ b/out-adapter-persistence-jpa/src/main/java/gohigher/position/entity/PositionPersistenceQueryAdapter.java
@@ -1,0 +1,24 @@
+package gohigher.position.entity;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import gohigher.position.Position;
+import gohigher.position.port.out.PositionPersistenceQueryPort;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class PositionPersistenceQueryAdapter implements PositionPersistenceQueryPort {
+
+	private final PositionRepository positionRepository;
+
+	@Override
+	public List<Position> findAll() {
+		return positionRepository.findAll()
+			.stream()
+			.map(PositionJpaEntity::toDomain)
+			.toList();
+	}
+}

--- a/out-adapter-persistence-jpa/src/main/java/gohigher/position/entity/PositionRepository.java
+++ b/out-adapter-persistence-jpa/src/main/java/gohigher/position/entity/PositionRepository.java
@@ -1,0 +1,6 @@
+package gohigher.position.entity;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PositionRepository extends JpaRepository<PositionJpaEntity, Long> {
+}

--- a/out-adapter-persistence-jpa/src/main/java/gohigher/recruitment/entity/RecruitmentJpaEntity.java
+++ b/out-adapter-persistence-jpa/src/main/java/gohigher/recruitment/entity/RecruitmentJpaEntity.java
@@ -30,8 +30,8 @@ public class RecruitmentJpaEntity {
 	private String team;
 	private String location;
 	private String contact;
-	private String duty;
 	private String position;
+	private String specificPosition;
 	private String jobDescription;
 	private String workType;
 

--- a/out-adapter-persistence-jpa/src/test/java/gohigher/fixtureConverter/ApplicationFixtureConverter.java
+++ b/out-adapter-persistence-jpa/src/test/java/gohigher/fixtureConverter/ApplicationFixtureConverter.java
@@ -11,9 +11,9 @@ public class ApplicationFixtureConverter {
 
 	public static ApplicationJpaEntity convertToApplicationEntity(Long userId, Application application) {
 		return new ApplicationJpaEntity(null, userId, application.getCompanyName(), application.getTeam(),
-			application.getLocation(), application.getContact(), application.getDuty(), application.getPosition(),
-			application.getJobDescription(), application.getWorkType(), application.getEmploymentType(),
-			application.getCareerRequirement(), application.getRequiredCapability(),
+			application.getLocation(), application.getContact(), application.getPosition(),
+			application.getSpecificPosition(), application.getJobDescription(), application.getWorkType(),
+			application.getEmploymentType(), application.getCareerRequirement(), application.getRequiredCapability(),
 			application.getPreferredQualification(), application.getUrl(), 0, new ArrayList<>(), null, false);
 	}
 


### PR DESCRIPTION
## 작업 내용
- duty라는 필드명 position으로 변경
- position이라는 필드명 specificPosition으로 변경
duty는 직무 보다는 업무의 느낌이 강해서 position이라는 네이밍으로 변경했습니다!
- 직무 목록 전체 조회 API 구현

세부 직무들을 함께 조회하는 것이 아니라, 직무 목록만을 조회하는 API입니다.
Paging에 대해서 고민해보았는데요. 큰 직무 카테고리가 현재 많지 않고 많아봤자 30~50개 정도 될 것 같습니다. 또한, View도 Paging 처리할 View가 아니라서 Paging 처리하지 않았습니다!

resolve #89 
