### PR TITLE
[REFACTOR] 페이징 응답 필드명 변경

### DIFF
--- a/core-application/src/main/java/gohigher/application/port/in/PagingResponse.java
+++ b/core-application/src/main/java/gohigher/application/port/in/PagingResponse.java
@@ -9,6 +9,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class PagingResponse<E> {
 
-	private final boolean lastPage;
+	private final boolean hasNext;
 	private final List<E> content;
 }

--- a/core-application/src/main/java/gohigher/application/service/ApplicationQueryService.java
+++ b/core-application/src/main/java/gohigher/application/service/ApplicationQueryService.java
@@ -66,7 +66,7 @@ public class ApplicationQueryService implements ApplicationQueryPort {
 		PagingContainer<Application> pagingContainer = applicationPersistenceQueryPort.findUnscheduledByUserId(
 			userId, request.getPage(), request.getSize());
 		List<UnscheduledApplicationResponse> responses = findUnscheduledByUserId(pagingContainer.getContent());
-		return new PagingResponse<>(pagingContainer.isLastPage(), responses);
+		return new PagingResponse<>(pagingContainer.hasNext(), responses);
 	}
 
 	@Override

--- a/core-domain/src/main/java/gohigher/pagination/PagingContainer.java
+++ b/core-domain/src/main/java/gohigher/pagination/PagingContainer.java
@@ -9,6 +9,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class PagingContainer<E> {
 
-	private final boolean lastPage;
+	private final boolean hasNext;
 	private final List<E> content;
+
+	public boolean hasNext() {
+		return hasNext;
+	}
 }

--- a/in-adapter-api/src/main/java/gohigher/application/ApplicationQueryControllerDocs.java
+++ b/in-adapter-api/src/main/java/gohigher/application/ApplicationQueryControllerDocs.java
@@ -115,7 +115,7 @@ public interface ApplicationQueryControllerDocs {
 			}))
 	})
 	ResponseEntity<GohigherResponse<PagingResponse<UnscheduledApplicationResponse>>> findUnscheduled(
-		@Login Long userId, @ModelAttribute PagingRequest request);
+		@Parameter(hidden = true) @Login Long userId, @ModelAttribute PagingRequest request);
 
 	@Operation(summary = "칸반 지원서 목록 조회")
 	@ApiResponses(

--- a/in-adapter-api/src/main/java/gohigher/config/SwaggerConfig.java
+++ b/in-adapter-api/src/main/java/gohigher/config/SwaggerConfig.java
@@ -3,6 +3,8 @@ package gohigher.config;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -16,7 +18,8 @@ public class SwaggerConfig {
                 .description("Go-Higher API DOCS");
 
         return new OpenAPI()
-                .components(new Components())
-                .info(info);
+            .addServersItem(new Server().url("/"))
+            .components(new Components())
+            .info(info);
     }
 }


### PR DESCRIPTION
## 작업 내용
- 페이징 API 응답 필드명을 변경하였습니다. (`lastPage` -> `hasNext`)
  - 의미는 hasNext 가 맞습니다. (다음 페이지가 있을 경우 true 응답)
- 스웨거 요청 URL 을 루트(`/`) 로 변경하였습니다.
  - 개발 서버에 https 로 접근 시 스웨거의 기본 요청 URL 이 http 이기 때문에 CORS 가 발생하여 요청을 보낼 수 없습니다.

resolve #118 
