### PR TITLE
[FEATURE] 전형 순서를 ProcessType별로 관리하도록 변경

### DIFF
--- a/core-application/src/main/java/gohigher/application/port/out/persistence/ApplicationPersistenceCommandPort.java
+++ b/core-application/src/main/java/gohigher/application/port/out/persistence/ApplicationPersistenceCommandPort.java
@@ -6,5 +6,5 @@ public interface ApplicationPersistenceCommandPort {
 
 	Application save(Long userId, Application application);
 
-	void updateCurrentProcessOrder(long id, long processId);
+	void updateCurrentProcessOrder(long id, long userId, long processId);
 }

--- a/core-application/src/main/java/gohigher/application/service/ApplicationCommandService.java
+++ b/core-application/src/main/java/gohigher/application/service/ApplicationCommandService.java
@@ -43,7 +43,7 @@ public class ApplicationCommandService implements ApplicationCommandPort {
 		Long applicationId = request.getApplicationId();
 		validateNotFound(userId, applicationId);
 		validateProcessNotFound(request.getProcessId());
-		applicationPersistenceCommandPort.updateCurrentProcessOrder(applicationId, request.getProcessId());
+		applicationPersistenceCommandPort.updateCurrentProcessOrder(applicationId, userId, request.getProcessId());
 	}
 
 	private void validateNotFound(Long userId, Long applicationId) {

--- a/core-application/src/test/java/gohigher/application/service/ApplicationCommandServiceTest.java
+++ b/core-application/src/test/java/gohigher/application/service/ApplicationCommandServiceTest.java
@@ -108,7 +108,7 @@ class ApplicationCommandServiceTest {
 
 				//then
 				verify(applicationPersistenceCommandPort)
-					.updateCurrentProcessOrder(request.getApplicationId(), request.getProcessId());
+					.updateCurrentProcessOrder(request.getApplicationId(), userId, request.getProcessId());
 			}
 		}
 	}

--- a/core-application/src/test/java/gohigher/application/service/ApplicationQueryServiceTest.java
+++ b/core-application/src/test/java/gohigher/application/service/ApplicationQueryServiceTest.java
@@ -150,7 +150,7 @@ class ApplicationQueryServiceTest {
 		class Context_with_schedules {
 
 			Process interview = INTERVIEW.toDomainWithSchedule(date);
-			Process document = DOCUMENT.toDomainWithSchedule(date);
+			Process test = TEST.toDomainWithSchedule(date);
 
 			@DisplayName("일정 정보를 반환한다.")
 			@Test
@@ -158,8 +158,8 @@ class ApplicationQueryServiceTest {
 				// given
 				List<Process> naverProcesses = List.of(this.interview);
 				Application naverApplication = NAVER_APPLICATION.toDomain(naverProcesses, interview);
-				List<Process> kakaoProcesses = List.of(this.document);
-				Application kakaoApplication = KAKAO_APPLICATION.toDomain(kakaoProcesses, document);
+				List<Process> kakaoProcesses = List.of(this.test);
+				Application kakaoApplication = KAKAO_APPLICATION.toDomain(kakaoProcesses, test);
 				given(applicationPersistenceQueryPort.findByUserIdAndDate(userId, date)).willReturn(
 					List.of(naverApplication, kakaoApplication));
 
@@ -191,7 +191,7 @@ class ApplicationQueryServiceTest {
 				int size = 10;
 				PagingRequest request = new PagingRequest(page, size);
 
-				Process process = TO_APPLY.toPersistedDomain(1);
+				Process process = TEST.toPersistedDomain(1);
 				List<Application> applications = List.of(
 					NAVER_APPLICATION.toPersistedDomain(1, List.of(process), process));
 				given(applicationPersistenceQueryPort.findUnscheduledByUserId(userId, page, size))

--- a/core-application/src/test/java/gohigher/application/service/ApplicationQueryServiceTest.java
+++ b/core-application/src/test/java/gohigher/application/service/ApplicationQueryServiceTest.java
@@ -157,9 +157,9 @@ class ApplicationQueryServiceTest {
 			void it_return_processes() {
 				// given
 				List<Process> naverProcesses = List.of(this.interview);
-				Application naverApplication = NAVER_APPLICATION.toDomain(naverProcesses, null);
+				Application naverApplication = NAVER_APPLICATION.toDomain(naverProcesses, interview);
 				List<Process> kakaoProcesses = List.of(this.document);
-				Application kakaoApplication = KAKAO_APPLICATION.toDomain(kakaoProcesses, null);
+				Application kakaoApplication = KAKAO_APPLICATION.toDomain(kakaoProcesses, document);
 				given(applicationPersistenceQueryPort.findByUserIdAndDate(userId, date)).willReturn(
 					List.of(naverApplication, kakaoApplication));
 

--- a/core-domain/src/main/java/gohigher/application/ApplicationErrorCode.java
+++ b/core-domain/src/main/java/gohigher/application/ApplicationErrorCode.java
@@ -16,6 +16,7 @@ public enum ApplicationErrorCode implements ErrorCode {
 
 	INVALID_DATE_INFO(400, "APPLICATION_011", "잘못된 날짜 정보입니다."),
 	INVALID_DATE_PATTERN(400, "APPLICATION_012", "잘못된 날짜 형식입니다."),
+	CURRENT_PROCESS_NOT_FOUND(400, "APPLICATION_013", "현재 전형 단계를 조회하지 못했습니다."),
 	;
 
 	private final int statusCode;

--- a/core-domain/src/main/java/gohigher/common/JobInfo.java
+++ b/core-domain/src/main/java/gohigher/common/JobInfo.java
@@ -43,6 +43,6 @@ public abstract class JobInfo {
 	protected final String url;
 
 	public List<Process> getProcesses() {
-		return processes.getValues();
+		return processes.getOrderedValues();
 	}
 }

--- a/core-domain/src/main/java/gohigher/common/JobInfo.java
+++ b/core-domain/src/main/java/gohigher/common/JobInfo.java
@@ -43,6 +43,6 @@ public abstract class JobInfo {
 	protected final String url;
 
 	public List<Process> getProcesses() {
-		return processes.getOrderedValues();
+		return processes.getSortedValues();
 	}
 }

--- a/core-domain/src/main/java/gohigher/common/Processes.java
+++ b/core-domain/src/main/java/gohigher/common/Processes.java
@@ -1,6 +1,9 @@
 package gohigher.common;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -9,25 +12,41 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class Processes {
 
-	public static final Process DEFAULT_PROCESS = new Process(ProcessType.TO_APPLY, "", null, 1);
+	private static final int INITIAL_ORDER = 1;
 
-	private final List<Process> values;
+	private final Map<ProcessType, List<Process>> values;
+
+	public static Processes of(List<Process> processes) {
+		return new Processes(groupingByProcessType(processes));
+	}
 
 	public static Processes initialFrom(List<Process> processes) {
-		if (processes.isEmpty()) {
-			processes.add(DEFAULT_PROCESS);
+		Map<ProcessType, List<Process>> values = groupingByProcessType(processes);
+
+		for (ProcessType processType : values.keySet()) {
+			assignNewOrder(values.get(processType));
 		}
 
-		assignNewOrder(processes);
+		return new Processes(values);
+	}
 
-		return new Processes(processes);
+	private static Map<ProcessType, List<Process>> groupingByProcessType(List<Process> processes) {
+		return processes.stream()
+			.collect(Collectors.groupingBy(Process::getType));
 	}
 
 	private static void assignNewOrder(List<Process> processes) {
-		int nextOrder = 1;
+		int nextOrder = INITIAL_ORDER;
 		for (Process process : processes) {
 			process.assignOrder(nextOrder);
 			nextOrder++;
 		}
+	}
+
+	public List<Process> getOrderedValues() {
+		return Arrays.stream(ProcessType.values())
+			.filter(values::containsKey)
+			.flatMap(processType -> values.get(processType).stream())
+			.collect(Collectors.toList());
 	}
 }

--- a/core-domain/src/main/java/gohigher/common/Processes.java
+++ b/core-domain/src/main/java/gohigher/common/Processes.java
@@ -71,7 +71,7 @@ public class Processes {
 		}
 	}
 
-	public List<Process> getOrderedValues() {
+	public List<Process> getSortedValues() {
 		return Arrays.stream(ProcessType.values())
 			.filter(values::containsKey)
 			.flatMap(processType -> values.get(processType).stream())

--- a/core-domain/src/test/java/gohigher/common/ProcessesTest.java
+++ b/core-domain/src/test/java/gohigher/common/ProcessesTest.java
@@ -154,9 +154,9 @@ class ProcessesTest {
 		}
 	}
 
-	@DisplayName("getOrderedValues 메소드는")
+	@DisplayName("getSortedValues 메소드는")
 	@Nested
-	class Describe_getOrderedValues {
+	class Describe_getSortedValues {
 
 		@DisplayName("여러 전형을 갖고 있을 경우")
 		@Nested

--- a/core-domain/src/test/java/gohigher/common/ProcessesTest.java
+++ b/core-domain/src/test/java/gohigher/common/ProcessesTest.java
@@ -72,8 +72,10 @@ class ProcessesTest {
 				List<Process> interviewProcesses = processes.getValues().get(ProcessType.INTERVIEW);
 
 				assertAll(
+					() -> assertThat(testProcesses).containsExactly(test1, test2),
 					() -> assertThat(testProcesses.get(0).getOrder()).isEqualTo(1),
 					() -> assertThat(testProcesses.get(1).getOrder()).isEqualTo(2),
+					() -> assertThat(interviewProcesses).containsExactly(interview1, interview2),
 					() -> assertThat(interviewProcesses.get(0).getOrder()).isEqualTo(1),
 					() -> assertThat(interviewProcesses.get(1).getOrder()).isEqualTo(2)
 				);

--- a/core-domain/src/test/java/gohigher/common/ProcessesTest.java
+++ b/core-domain/src/test/java/gohigher/common/ProcessesTest.java
@@ -18,6 +18,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
+import gohigher.application.ProcessFixture;
+
 @DisplayName("Processes 클래스의")
 class ProcessesTest {
 
@@ -146,6 +148,33 @@ class ProcessesTest {
 					() -> assertThat(processes.keySet()).hasSize(1),
 					() -> assertThat(processes.get(processType)).contains(process)
 				);
+			}
+		}
+	}
+
+	@DisplayName("getOrderedValues 메소드는")
+	@Nested
+	class Describe_getOrderedValues {
+
+		@DisplayName("여러 전형을 갖고 있을 경우")
+		@Nested
+		class Context_with_many_processes {
+
+			private final Process toApply = ProcessFixture.TO_APPLY.toDomainWithoutOrder();
+			private final Process document = ProcessFixture.DOCUMENT.toDomainWithoutOrder();
+			private final Process test1 = TEST.toDomainWithoutOrder();
+			private final Process test2 = CODING_TEST.toDomainWithoutOrder();
+			private final Process interview1 = FIRST_INTERVIEW.toDomainWithoutOrder();
+			private final Process interview2 = SECOND_INTERVIEW.toDomainWithoutOrder();
+			private final List<Process> input = List.of(toApply, document, test1, test2, interview1, interview2);
+
+			@DisplayName("ProccessType과 Order에 따라 정렬된 전형들을 반환한다.")
+			@Test
+			void it_returns_sorted_values() {
+				Processes processes = Processes.initialFrom(input);
+				List<Process> sortedProcesses = processes.getSortedValues();
+
+				assertThat(sortedProcesses).containsOnly(toApply, document, test1, test2, interview1, interview2);
 			}
 		}
 	}

--- a/core-domain/src/test/java/gohigher/common/ProcessesTest.java
+++ b/core-domain/src/test/java/gohigher/common/ProcessesTest.java
@@ -4,7 +4,6 @@ import static gohigher.application.ProcessFixture.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -14,6 +13,33 @@ import org.junit.jupiter.api.Test;
 @DisplayName("Processes 클래스의")
 class ProcessesTest {
 
+	@DisplayName("of 정적 팩터리 메소드는")
+	@Nested
+	class Describe_of {
+
+		@DisplayName("중복된 ProcessType의 Process들을 받을 경우")
+		@Nested
+		class Context_with_processes_that_duplicated_process_type {
+
+			private final Process test1 = TEST.toDomainWithoutOrder();
+			private final Process test2 = CODING_TEST.toDomainWithoutOrder();
+			private final Process interview1 = FIRST_INTERVIEW.toDomainWithoutOrder();
+			private final Process interview2 = SECOND_INTERVIEW.toDomainWithoutOrder();
+			private final List<Process> input = List.of(test1, test2, interview1, interview2);
+
+			@DisplayName("ProcessType별로 분리하여 저장된 Processes객체를 반환한다.")
+			@Test
+			void it_returns_processes_that_assigned_order() {
+				Processes processes = Processes.of(input);
+
+				assertAll(
+					() -> assertThat(processes.getValues().get(ProcessType.TEST)).contains(test1, test2),
+					() -> assertThat(processes.getValues().get(ProcessType.INTERVIEW)).contains(interview1, interview2)
+				);
+			}
+		}
+	}
+
 	@DisplayName("initiallyFrom 정적 팩터리 메소드는")
 	@Nested
 	class Describe_initiallyFrom {
@@ -22,40 +48,24 @@ class ProcessesTest {
 		@Nested
 		class Context_with_processes_that_not_assigned_order {
 
-			private final Process toApply = TO_APPLY.toDomainWithoutOrder();
-			private final Process document = DOCUMENT.toDomainWithoutOrder();
-			private final Process test = TEST.toDomainWithoutOrder();
-			private final Process interview = INTERVIEW.toDomainWithoutOrder();
-			private final List<Process> input = List.of(toApply, document, test, interview);
+			private final Process test1 = TEST.toDomainWithoutOrder();
+			private final Process test2 = CODING_TEST.toDomainWithoutOrder();
+			private final Process interview1 = FIRST_INTERVIEW.toDomainWithoutOrder();
+			private final Process interview2 = SECOND_INTERVIEW.toDomainWithoutOrder();
+			private final List<Process> input = List.of(test1, test2, interview1, interview2);
 
-			@DisplayName("Order를 순차적으로 할당하며 생성한다.")
+			@DisplayName("ProcessType별로 Order를 1번부터 순차적으로 할당한 Processes객체를 반환한다.")
 			@Test
 			void it_returns_processes_that_assigned_order() {
 				Processes processes = Processes.initialFrom(input);
+				List<Process> testProcesses = processes.getValues().get(ProcessType.TEST);
+				List<Process> interviewProcesses = processes.getValues().get(ProcessType.INTERVIEW);
 
 				assertAll(
-					() -> assertThat(processes.getValues().get(0).getOrder()).isEqualTo(1),
-					() -> assertThat(processes.getValues().get(1).getOrder()).isEqualTo(2),
-					() -> assertThat(processes.getValues().get(2).getOrder()).isEqualTo(3),
-					() -> assertThat(processes.getValues().get(3).getOrder()).isEqualTo(4)
-				);
-			}
-		}
-
-		@DisplayName("비어있는 Process리스트를 받을 경우")
-		@Nested
-		class Context_with_empty_processes {
-
-			private final List<Process> input = new ArrayList<>();
-
-			@DisplayName("지원예정 과정이 추가된 과정리스트를 반환한다.")
-			@Test
-			void it_returns_processes_with_default_process() {
-				Processes processes = Processes.initialFrom(input);
-
-				assertAll(
-					() -> assertThat(processes.getValues()).hasSize(1),
-					() -> assertThat(processes.getValues().get(0).getType()).isEqualTo(ProcessType.TO_APPLY)
+					() -> assertThat(testProcesses.get(0).getOrder()).isEqualTo(1),
+					() -> assertThat(testProcesses.get(1).getOrder()).isEqualTo(2),
+					() -> assertThat(interviewProcesses.get(0).getOrder()).isEqualTo(1),
+					() -> assertThat(interviewProcesses.get(1).getOrder()).isEqualTo(2)
 				);
 			}
 		}

--- a/core-domain/src/testFixtures/java/gohigher/application/ApplicationFixture.java
+++ b/core-domain/src/testFixtures/java/gohigher/application/ApplicationFixture.java
@@ -1,6 +1,9 @@
 package gohigher.application;
 
+import static gohigher.application.ProcessFixture.*;
+
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import gohigher.common.EmploymentType;
@@ -42,6 +45,19 @@ public enum ApplicationFixture {
 
 	public Application toDomain() {
 		return new Builder(this).toDomain(null);
+	}
+
+	public Application toDomain(Process... args) {
+		List<Process> processes = Arrays.stream(args).toList();
+		return toDomain(processes, processes.get(0));
+	}
+
+	public Application toDomain(ProcessFixture... args) {
+		List<Process> processes = Arrays.stream(args)
+			.map(ProcessFixture::toDomain)
+			.toList();
+
+		return toDomain(processes, processes.get(0));
 	}
 
 	public Application toDomain(List<Process> processes, Process currentProcess) {
@@ -105,6 +121,12 @@ public enum ApplicationFixture {
 		}
 
 		public Application toDomain(Long id) {
+			if (processes.isEmpty()) {
+				Process toApplyProcess = TO_APPLY.toDomain();
+				processes = List.of(toApplyProcess);
+				currentProcess = toApplyProcess;
+			}
+
 			return new Application(id, companyName, team, location, contact, position, specificPosition, jobDescription,
 				workType, employmentType, careerRequirement, requiredCapability, preferredQualification,
 				Processes.initialFrom(processes), url, currentProcess);

--- a/core-domain/src/testFixtures/java/gohigher/application/ProcessFixture.java
+++ b/core-domain/src/testFixtures/java/gohigher/application/ProcessFixture.java
@@ -13,7 +13,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ProcessFixture {
 
-	TO_APPLY(ProcessType.TO_APPLY, "지원 예정", null, 1),
+	TO_APPLY(ProcessType.TO_APPLY, "지원 예정", LocalDateTime.now().plusDays(6), 1),
 	DOCUMENT(ProcessType.DOCUMENT, "서류 전형", LocalDateTime.now().plusDays(6), 2),
 	TEST(ProcessType.TEST, "시험", LocalDateTime.now().plusDays(10), 3),
 	CODING_TEST(ProcessType.TEST, "코딩테스트", LocalDateTime.now().plusDays(10), 4),
@@ -32,7 +32,7 @@ public enum ProcessFixture {
 		return createProcess(null, type, description, schedule, order);
 	}
 
-	public Process toDomainWithScheduleAndOrder(LocalDateTime schedule, int order) {
+	public Process toDomainWithSchedule(LocalDateTime schedule) {
 		return createProcess(null, type, description, schedule, order);
 	}
 
@@ -42,10 +42,6 @@ public enum ProcessFixture {
 
 	public Process toDomainWithoutOrder() {
 		return createProcess(null, type, description, schedule, 0);
-	}
-
-	public Process toDomainWithDescription(String description) {
-		return createProcess(null, type, description, schedule, order);
 	}
 
 	public Process toPersistedDomain(long id) {

--- a/out-adapter-persistence-jpa/src/main/java/gohigher/application/ApplicationPersistenceCommandAdapter.java
+++ b/out-adapter-persistence-jpa/src/main/java/gohigher/application/ApplicationPersistenceCommandAdapter.java
@@ -1,5 +1,7 @@
 package gohigher.application;
 
+import static gohigher.application.ApplicationErrorCode.*;
+
 import java.util.List;
 
 import org.springframework.stereotype.Component;
@@ -10,6 +12,7 @@ import gohigher.application.entity.ApplicationProcessRepository;
 import gohigher.application.entity.ApplicationRepository;
 import gohigher.application.port.out.persistence.ApplicationPersistenceCommandPort;
 import gohigher.common.Process;
+import gohigher.global.exception.GoHigherException;
 import lombok.RequiredArgsConstructor;
 
 @Component
@@ -39,6 +42,11 @@ public class ApplicationPersistenceCommandAdapter implements ApplicationPersiste
 
 	@Override
 	public void updateCurrentProcessOrder(long id, long processId) {
-		applicationRepository.updateCurrentProcessOrder(id, processId);
+		ApplicationJpaEntity application = applicationRepository.findById(id)
+			.orElseThrow(() -> new GoHigherException(APPLICATION_NOT_FOUND));
+		ApplicationProcessJpaEntity process = applicationProcessRepository.findById(processId)
+			.orElseThrow(() -> new GoHigherException(APPLICATION_PROCESS_NOT_FOUND));
+
+		application.updateCurrentProcess(process.getType(), process.getOrder());
 	}
 }

--- a/out-adapter-persistence-jpa/src/main/java/gohigher/application/ApplicationPersistenceCommandAdapter.java
+++ b/out-adapter-persistence-jpa/src/main/java/gohigher/application/ApplicationPersistenceCommandAdapter.java
@@ -1,5 +1,7 @@
 package gohigher.application;
 
+import static gohigher.application.ApplicationErrorCode.*;
+
 import java.util.List;
 
 import org.springframework.stereotype.Component;
@@ -10,6 +12,7 @@ import gohigher.application.entity.ApplicationProcessRepository;
 import gohigher.application.entity.ApplicationRepository;
 import gohigher.application.port.out.persistence.ApplicationPersistenceCommandPort;
 import gohigher.common.Process;
+import gohigher.global.exception.GoHigherException;
 import lombok.RequiredArgsConstructor;
 
 @Component
@@ -39,13 +42,19 @@ public class ApplicationPersistenceCommandAdapter implements ApplicationPersiste
 		applicationProcessRepository.saveAll(applicationJpaEntity.getProcesses());
 	}
 
-	// @Override
-	// public void updateCurrentProcessOrder(long id, long processId) {
-	// 	ApplicationJpaEntity application = applicationRepository.findById(id)
-	// 		.orElseThrow(() -> new GoHigherException(APPLICATION_NOT_FOUND));
-	// 	ApplicationProcessJpaEntity process = applicationProcessRepository.findById(processId)
-	// 		.orElseThrow(() -> new GoHigherException(APPLICATION_PROCESS_NOT_FOUND));
-	//
-	// 	application.updateCurrentProcess(process.getType(), process.getOrder());
-	// }
+	@Override
+	public void updateCurrentProcessOrder(long id, long userId, long processId) {
+		ApplicationJpaEntity application = applicationRepository.findByIdAndUserIdWithProcess(id, userId)
+			.orElseThrow(() -> new GoHigherException(APPLICATION_NOT_FOUND));
+
+		for (ApplicationProcessJpaEntity process : application.getProcesses()) {
+			if (process.isCurrent()) {
+				process.changeToNonCurrentProcess();
+			}
+
+			if (process.getId() == processId) {
+				process.changeToCurrentProcess();
+			}
+		}
+	}
 }

--- a/out-adapter-persistence-jpa/src/main/java/gohigher/application/entity/ApplicationJpaEntity.java
+++ b/out-adapter-persistence-jpa/src/main/java/gohigher/application/entity/ApplicationJpaEntity.java
@@ -6,6 +6,7 @@ import java.util.List;
 import gohigher.application.Application;
 import gohigher.common.EmploymentType;
 import gohigher.common.Process;
+import gohigher.common.ProcessType;
 import gohigher.common.Processes;
 import gohigher.recruitment.entity.RecruitmentJpaEntity;
 import jakarta.persistence.Entity;
@@ -53,6 +54,9 @@ public class ApplicationJpaEntity {
 	private String requiredCapability;
 	private String preferredQualification;
 	private String url;
+
+	@Enumerated(value = EnumType.STRING)
+	private ProcessType currentProcessType;
 	private int currentProcessOrder;
 
 	@OneToMany(mappedBy = "application")
@@ -80,7 +84,8 @@ public class ApplicationJpaEntity {
 			application.getRequiredCapability(),
 			application.getPreferredQualification(),
 			application.getUrl(),
-			FIRST_PROCESS_ORDER,
+			application.getCurrentProcess().getType(),
+			application.getCurrentProcess().getOrder(),
 			null,
 			null,
 			false
@@ -116,6 +121,7 @@ public class ApplicationJpaEntity {
 
 	private Process findCurrentProcess(List<Process> processes) {
 		return processes.stream()
+			.filter(process -> process.getType() == currentProcessType)
 			.filter(process -> process.getOrder() == currentProcessOrder)
 			.findAny()
 			.orElse(null);

--- a/out-adapter-persistence-jpa/src/main/java/gohigher/application/entity/ApplicationJpaEntity.java
+++ b/out-adapter-persistence-jpa/src/main/java/gohigher/application/entity/ApplicationJpaEntity.java
@@ -139,4 +139,9 @@ public class ApplicationJpaEntity {
 			workType, employmentType, careerRequirement, requiredCapability, preferredQualification,
 			Processes.of(processes), url, currentProcess);
 	}
+
+	public void updateCurrentProcess(ProcessType type, int order) {
+		currentProcessType = type;
+		currentProcessOrder = order;
+	}
 }

--- a/out-adapter-persistence-jpa/src/main/java/gohigher/application/entity/ApplicationJpaEntity.java
+++ b/out-adapter-persistence-jpa/src/main/java/gohigher/application/entity/ApplicationJpaEntity.java
@@ -103,13 +103,6 @@ public class ApplicationJpaEntity {
 		return createApplication(processes, findCurrentProcess(processes));
 	}
 
-	public Application toDomain(List<ApplicationProcessJpaEntity> applicationProcessJpaEntities) {
-		List<Process> processes = applicationProcessJpaEntities.stream()
-			.map(ApplicationProcessJpaEntity::toDomain)
-			.toList();
-		return createApplication(processes, findCurrentProcess(processes));
-	}
-
 	public Application toCalenderDomain() {
 		List<Process> processes = getProcessList();
 		return createApplication(processes, null);
@@ -144,9 +137,4 @@ public class ApplicationJpaEntity {
 			workType, employmentType, careerRequirement, requiredCapability, preferredQualification,
 			Processes.of(processes), url, currentProcess);
 	}
-
-	// public void updateCurrentProcess(ProcessType type, int order) {
-	// 	currentProcessType = type;
-	// 	currentProcessOrder = order;
-	// }
 }

--- a/out-adapter-persistence-jpa/src/main/java/gohigher/application/entity/ApplicationJpaEntity.java
+++ b/out-adapter-persistence-jpa/src/main/java/gohigher/application/entity/ApplicationJpaEntity.java
@@ -131,6 +131,6 @@ public class ApplicationJpaEntity {
 	private Application createApplication(List<Process> processes, Process currentProcess) {
 		return new Application(id, companyName, team, location, contact, position, specificPosition, jobDescription,
 			workType, employmentType, careerRequirement, requiredCapability, preferredQualification,
-			new Processes(processes), url, currentProcess);
+			Processes.of(processes), url, currentProcess);
 	}
 }

--- a/out-adapter-persistence-jpa/src/main/java/gohigher/application/entity/ApplicationProcessJpaEntity.java
+++ b/out-adapter-persistence-jpa/src/main/java/gohigher/application/entity/ApplicationProcessJpaEntity.java
@@ -44,9 +44,11 @@ public class ApplicationProcessJpaEntity {
 	private LocalDateTime schedule;
 	private String description;
 
-	public static ApplicationProcessJpaEntity of(ApplicationJpaEntity application, Process process) {
+	private boolean isCurrent;
+
+	public static ApplicationProcessJpaEntity of(ApplicationJpaEntity application, Process process, boolean isCurrent) {
 		return new ApplicationProcessJpaEntity(process.getId(), application, process.getType(), process.getOrder(),
-			process.getSchedule(), process.getDescription());
+			process.getSchedule(), process.getDescription(), isCurrent);
 	}
 
 	public void assignApplication(ApplicationJpaEntity application) {

--- a/out-adapter-persistence-jpa/src/main/java/gohigher/application/entity/ApplicationProcessJpaEntity.java
+++ b/out-adapter-persistence-jpa/src/main/java/gohigher/application/entity/ApplicationProcessJpaEntity.java
@@ -55,6 +55,14 @@ public class ApplicationProcessJpaEntity {
 		this.application = application;
 	}
 
+	public void changeToCurrentProcess() {
+		isCurrent = true;
+	}
+
+	public void changeToNonCurrentProcess() {
+		isCurrent = false;
+	}
+
 	public Process toDomain() {
 		return new Process(id, type, description, schedule, order);
 	}

--- a/out-adapter-persistence-jpa/src/main/java/gohigher/application/entity/ApplicationRepository.java
+++ b/out-adapter-persistence-jpa/src/main/java/gohigher/application/entity/ApplicationRepository.java
@@ -39,8 +39,7 @@ public interface ApplicationRepository extends JpaRepository<ApplicationJpaEntit
 	@Query("SELECT a FROM ApplicationJpaEntity a "
 		+ "JOIN FETCH a.processes p "
 		+ "WHERE a.userId = :userId "
-		+ "AND a.currentProcessType = p.type "
-		+ "AND a.currentProcessOrder = p.order "
+		+ "AND p.isCurrent = true "
 		+ "AND p.schedule = null "
 		+ "AND a.deleted = false")
 	Slice<ApplicationJpaEntity> findUnscheduledByUserId(Long userId, Pageable pageable);
@@ -48,8 +47,7 @@ public interface ApplicationRepository extends JpaRepository<ApplicationJpaEntit
 	@Query("SELECT a FROM ApplicationJpaEntity a "
 		+ "JOIN FETCH a.processes p "
 		+ "WHERE a.userId = :userId "
-		+ "AND a.currentProcessType = p.type "
-		+ "AND a.currentProcessOrder = p.order "
+		+ "AND p.isCurrent = true "
 		+ "AND a.deleted = false")
 	List<ApplicationJpaEntity> findOnlyWithCurrentProcessByUserId(Long userId);
 }

--- a/out-adapter-persistence-jpa/src/main/java/gohigher/application/entity/ApplicationRepository.java
+++ b/out-adapter-persistence-jpa/src/main/java/gohigher/application/entity/ApplicationRepository.java
@@ -47,6 +47,7 @@ public interface ApplicationRepository extends JpaRepository<ApplicationJpaEntit
 	@Query("SELECT a FROM ApplicationJpaEntity a "
 		+ "JOIN FETCH a.processes p "
 		+ "WHERE a.userId = :userId "
+		+ "AND a.currentProcessType = p.type "
 		+ "AND a.currentProcessOrder = p.order "
 		+ "AND p.schedule = null "
 		+ "AND a.deleted = false")
@@ -55,6 +56,7 @@ public interface ApplicationRepository extends JpaRepository<ApplicationJpaEntit
 	@Query("SELECT a FROM ApplicationJpaEntity a "
 		+ "JOIN FETCH a.processes p "
 		+ "WHERE a.userId = :userId "
+		+ "AND a.currentProcessType = p.type "
 		+ "AND a.currentProcessOrder = p.order "
 		+ "AND a.deleted = false")
 	List<ApplicationJpaEntity> findOnlyWithCurrentProcessByUserId(Long userId);

--- a/out-adapter-persistence-jpa/src/main/java/gohigher/application/entity/ApplicationRepository.java
+++ b/out-adapter-persistence-jpa/src/main/java/gohigher/application/entity/ApplicationRepository.java
@@ -7,7 +7,6 @@ import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 public interface ApplicationRepository extends JpaRepository<ApplicationJpaEntity, Long> {
@@ -20,13 +19,6 @@ public interface ApplicationRepository extends JpaRepository<ApplicationJpaEntit
 		+ "AND a.userId = :userId "
 		+ "AND a.deleted = false")
 	Optional<ApplicationJpaEntity> findByIdAndUserIdWithProcess(Long id, Long userId);
-
-	@Modifying
-	@Query("UPDATE ApplicationJpaEntity a "
-		+ "SET a.currentProcessOrder = "
-		+ "(SELECT ap.order FROM ApplicationProcessJpaEntity ap WHERE ap.id = :processId) "
-		+ "WHERE a.id = :id")
-	void updateCurrentProcessOrder(long id, long processId);
 
 	@Query("SELECT a FROM ApplicationJpaEntity a "
 		+ "JOIN FETCH a.processes p "

--- a/out-adapter-persistence-jpa/src/test/java/gohigher/application/ApplicationPersistenceCommandAdapterTest.java
+++ b/out-adapter-persistence-jpa/src/test/java/gohigher/application/ApplicationPersistenceCommandAdapterTest.java
@@ -82,41 +82,40 @@ class ApplicationPersistenceCommandAdapterTest {
 		@Nested
 		class UpdateCurrentProcessOrderWithId {
 
-			long applicationId;
-			long applicationProcessId;
-			ApplicationProcessJpaEntity expectedProcess;
+			private long applicationId;
+			private long secondProcessId;
+			private ApplicationProcessJpaEntity firstProcessJpaEntity;
+			private ApplicationProcessJpaEntity secondProcessJpaEntity;
 
 			@BeforeEach
 			void setUp() {
 				ApplicationJpaEntity applicationJpaEntity =
 					applicationRepository.save(ApplicationJpaEntity.of(application, USER_ID));
 				applicationId = applicationJpaEntity.getId();
-				ApplicationProcessJpaEntity firstProcessJpaEntity = applicationProcessRepository.save(
+
+				firstProcessJpaEntity = applicationProcessRepository.save(
 					ApplicationProcessJpaEntity.of(applicationJpaEntity, firstProcess, true));
-				ApplicationProcessJpaEntity secondProcessJpaEntity = applicationProcessRepository.save(
+				applicationJpaEntity.addProcess(firstProcessJpaEntity);
+
+				secondProcessJpaEntity = applicationProcessRepository.save(
 					ApplicationProcessJpaEntity.of(applicationJpaEntity, secondProcess, false));
-				applicationProcessId = secondProcessJpaEntity.getId();
-				expectedProcess = secondProcessJpaEntity;
+				applicationJpaEntity.addProcess(secondProcessJpaEntity);
+
+				secondProcessId = secondProcessJpaEntity.getId();
 			}
 
-			// @DisplayName("정상적으로 변경할 수 있다.")
-			// @Test
-			// void updateCurrentProcessOrder() {
-			// 	//when
-			// 	applicationPersistenceCommandAdapter.updateCurrentProcessOrder(applicationId, applicationProcessId);
-			//
-			// 	//then
-			// 	entityManager.flush();
-			// 	entityManager.clear();
-			//
-			// 	ApplicationJpaEntity updatedApplication = applicationRepository.findById(applicationId)
-			// 		.get();
-			//
-			// 	assertAll(
-			// 		() -> assertThat(updatedApplication.getCurrentProcessType()).isEqualTo(expectedProcess.getType()),
-			// 		() -> assertThat(updatedApplication.getCurrentProcessOrder()).isEqualTo(expectedProcess.getOrder())
-			// 	);
-			// }
+			@DisplayName("정상적으로 변경할 수 있다.")
+			@Test
+			void updateCurrentProcessOrder() {
+				//when
+				applicationPersistenceCommandAdapter.updateCurrentProcessOrder(applicationId, USER_ID, secondProcessId);
+
+				//then
+				assertAll(
+					() -> assertThat(firstProcessJpaEntity.isCurrent()).isFalse(),
+					() -> assertThat(secondProcessJpaEntity.isCurrent()).isTrue()
+				);
+			}
 		}
 	}
 }

--- a/out-adapter-persistence-jpa/src/test/java/gohigher/application/ApplicationPersistenceCommandAdapterTest.java
+++ b/out-adapter-persistence-jpa/src/test/java/gohigher/application/ApplicationPersistenceCommandAdapterTest.java
@@ -92,31 +92,31 @@ class ApplicationPersistenceCommandAdapterTest {
 					applicationRepository.save(ApplicationJpaEntity.of(application, USER_ID));
 				applicationId = applicationJpaEntity.getId();
 				ApplicationProcessJpaEntity firstProcessJpaEntity = applicationProcessRepository.save(
-					ApplicationProcessJpaEntity.of(applicationJpaEntity, firstProcess));
+					ApplicationProcessJpaEntity.of(applicationJpaEntity, firstProcess, true));
 				ApplicationProcessJpaEntity secondProcessJpaEntity = applicationProcessRepository.save(
-					ApplicationProcessJpaEntity.of(applicationJpaEntity, secondProcess));
+					ApplicationProcessJpaEntity.of(applicationJpaEntity, secondProcess, false));
 				applicationProcessId = secondProcessJpaEntity.getId();
 				expectedProcess = secondProcessJpaEntity;
 			}
 
-			@DisplayName("정상적으로 변경할 수 있다.")
-			@Test
-			void updateCurrentProcessOrder() {
-				//when
-				applicationPersistenceCommandAdapter.updateCurrentProcessOrder(applicationId, applicationProcessId);
-
-				//then
-				entityManager.flush();
-				entityManager.clear();
-
-				ApplicationJpaEntity updatedApplication = applicationRepository.findById(applicationId)
-					.get();
-
-				assertAll(
-					() -> assertThat(updatedApplication.getCurrentProcessType()).isEqualTo(expectedProcess.getType()),
-					() -> assertThat(updatedApplication.getCurrentProcessOrder()).isEqualTo(expectedProcess.getOrder())
-				);
-			}
+			// @DisplayName("정상적으로 변경할 수 있다.")
+			// @Test
+			// void updateCurrentProcessOrder() {
+			// 	//when
+			// 	applicationPersistenceCommandAdapter.updateCurrentProcessOrder(applicationId, applicationProcessId);
+			//
+			// 	//then
+			// 	entityManager.flush();
+			// 	entityManager.clear();
+			//
+			// 	ApplicationJpaEntity updatedApplication = applicationRepository.findById(applicationId)
+			// 		.get();
+			//
+			// 	assertAll(
+			// 		() -> assertThat(updatedApplication.getCurrentProcessType()).isEqualTo(expectedProcess.getType()),
+			// 		() -> assertThat(updatedApplication.getCurrentProcessOrder()).isEqualTo(expectedProcess.getOrder())
+			// 	);
+			// }
 		}
 	}
 }

--- a/out-adapter-persistence-jpa/src/test/java/gohigher/application/ApplicationPersistenceCommandAdapterTest.java
+++ b/out-adapter-persistence-jpa/src/test/java/gohigher/application/ApplicationPersistenceCommandAdapterTest.java
@@ -5,8 +5,6 @@ import static gohigher.application.ProcessFixture.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.List;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -30,8 +28,7 @@ class ApplicationPersistenceCommandAdapterTest {
 	private static final Long USER_ID = 1L;
 	private final Process firstProcess = TO_APPLY.toDomain();
 	private final Process secondProcess = DOCUMENT.toDomain();
-	private final Application application = NAVER_APPLICATION.toDomain(List.of(firstProcess, secondProcess),
-		firstProcess);
+	private final Application application = NAVER_APPLICATION.toDomain(firstProcess, secondProcess);
 
 	@Autowired
 	private ApplicationRepository applicationRepository;
@@ -69,7 +66,6 @@ class ApplicationPersistenceCommandAdapterTest {
 				ApplicationJpaEntity applicationJpaEntity = applicationRepository.findById(applicationId).get();
 				assertAll(
 					() -> assertThat(applicationJpaEntity.getProcesses()).hasSize(application.getProcesses().size()),
-					() -> assertThat(applicationJpaEntity.getCurrentProcessOrder()).isEqualTo(0),
 					() -> assertThat(applicationJpaEntity.getProcesses()).extracting("order", "description")
 						.contains(
 							tuple(firstProcess.getOrder(), firstProcess.getDescription()),

--- a/out-adapter-persistence-jpa/src/test/java/gohigher/application/ApplicationPersistenceQueryAdapterTest.java
+++ b/out-adapter-persistence-jpa/src/test/java/gohigher/application/ApplicationPersistenceQueryAdapterTest.java
@@ -55,7 +55,7 @@ class ApplicationPersistenceQueryAdapterTest {
 			void setUp() {
 				ApplicationJpaEntity naverApplication = convertToApplicationEntity(userId,
 					NAVER_APPLICATION.toDomain());
-				naverApplication.addProcess(convertToApplicationProcessEntity(naverApplication, TEST.toDomain()));
+				naverApplication.addProcess(convertToApplicationProcessEntity(naverApplication, TEST.toDomain(), true));
 				given(applicationRepository.findByIdAndUserIdWithProcess(applicationId, userId))
 					.willReturn(Optional.of(naverApplication));
 			}
@@ -111,13 +111,13 @@ class ApplicationPersistenceQueryAdapterTest {
 			void setUp() {
 				naverApplication = convertToApplicationEntity(userId, NAVER_APPLICATION.toDomain());
 				naverApplication.addProcess(convertToApplicationProcessEntity(naverApplication,
-					TEST.toDomainWithSchedule(LocalDate.of(year, month, 11))));
+					TEST.toDomainWithSchedule(LocalDate.of(year, month, 11)), true));
 				naverApplication.addProcess(convertToApplicationProcessEntity(naverApplication,
-					TO_APPLY.toDomainWithSchedule(LocalDate.of(year, month, 20))));
+					TO_APPLY.toDomainWithSchedule(LocalDate.of(year, month, 20)), false));
 
 				kakaoApplication = convertToApplicationEntity(userId, KAKAO_APPLICATION.toDomain());
 				kakaoApplication.addProcess(convertToApplicationProcessEntity(kakaoApplication,
-					TO_APPLY.toDomainWithSchedule(LocalDate.of(year, month, 11))));
+					TO_APPLY.toDomainWithSchedule(LocalDate.of(year, month, 11)), true));
 
 				List<ApplicationJpaEntity> applicationJpaEntities = List.of(naverApplication, kakaoApplication);
 
@@ -170,13 +170,13 @@ class ApplicationPersistenceQueryAdapterTest {
 			void setUp() {
 				naverApplication = convertToApplicationEntity(userId, NAVER_APPLICATION.toDomain());
 				naverApplication.addProcess(convertToApplicationProcessEntity(naverApplication,
-					TEST.toDomainWithSchedule(date)));
+					TEST.toDomainWithSchedule(date), true));
 				naverApplication.addProcess(convertToApplicationProcessEntity(naverApplication,
-					INTERVIEW.toDomainWithSchedule(date)));
+					INTERVIEW.toDomainWithSchedule(date), false));
 
 				kakaoApplication = convertToApplicationEntity(userId, KAKAO_APPLICATION.toDomain());
 				kakaoApplication.addProcess(convertToApplicationProcessEntity(kakaoApplication,
-					INTERVIEW.toDomainWithSchedule(date)));
+					INTERVIEW.toDomainWithSchedule(date), true));
 
 				List<ApplicationJpaEntity> applicationJpaEntities = List.of(naverApplication, kakaoApplication);
 

--- a/out-adapter-persistence-jpa/src/test/java/gohigher/application/ApplicationProcessPersistenceQueryAdapterTest.java
+++ b/out-adapter-persistence-jpa/src/test/java/gohigher/application/ApplicationProcessPersistenceQueryAdapterTest.java
@@ -56,17 +56,18 @@ class ApplicationProcessPersistenceQueryAdapterTest {
 
 			@BeforeEach
 			void setUp() {
+				Application application = NAVER_APPLICATION.toDomain(TEST, FIRST_INTERVIEW, SECOND_INTERVIEW);
 				ApplicationJpaEntity applicationJpaEntity = applicationRepository.save(
-					convertToApplicationEntity(USER_ID, NAVER_APPLICATION.toDomain()));
+					convertToApplicationEntity(USER_ID, application));
+
+				for (Process process : application.getProcesses()) {
+					ApplicationProcessJpaEntity applicationProcessJpaEntity = applicationProcessRepository.save(
+						convertToApplicationProcessEntity(applicationJpaEntity, process));
+
+					applicationJpaEntity.addProcess(applicationProcessJpaEntity);
+				}
+
 				applicationId = applicationJpaEntity.getId();
-				ApplicationProcessJpaEntity firstApplicationProcessJpaEntity =
-					convertToApplicationProcessEntity(applicationJpaEntity, DOCUMENT.toDomain());
-				ApplicationProcessJpaEntity secondApplicationProcessJpaEntity = convertToApplicationProcessEntity(
-					applicationJpaEntity, FIRST_INTERVIEW.toDomain());
-				ApplicationProcessJpaEntity thirdApplicationProcessJpaEntity = convertToApplicationProcessEntity(
-					applicationJpaEntity, SECOND_INTERVIEW.toDomain());
-				applicationProcessRepository.saveAll(List.of(firstApplicationProcessJpaEntity,
-					secondApplicationProcessJpaEntity, thirdApplicationProcessJpaEntity));
 			}
 
 			@DisplayName("정상적으로 찾을 수 있어야 한다.")

--- a/out-adapter-persistence-jpa/src/test/java/gohigher/application/ApplicationProcessPersistenceQueryAdapterTest.java
+++ b/out-adapter-persistence-jpa/src/test/java/gohigher/application/ApplicationProcessPersistenceQueryAdapterTest.java
@@ -62,7 +62,8 @@ class ApplicationProcessPersistenceQueryAdapterTest {
 
 				for (Process process : application.getProcesses()) {
 					ApplicationProcessJpaEntity applicationProcessJpaEntity = applicationProcessRepository.save(
-						convertToApplicationProcessEntity(applicationJpaEntity, process));
+						convertToApplicationProcessEntity(applicationJpaEntity, process,
+							application.getCurrentProcess()));
 
 					applicationJpaEntity.addProcess(applicationProcessJpaEntity);
 				}

--- a/out-adapter-persistence-jpa/src/test/java/gohigher/application/entity/ApplicationRepositoryTest.java
+++ b/out-adapter-persistence-jpa/src/test/java/gohigher/application/entity/ApplicationRepositoryTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -46,47 +47,20 @@ class ApplicationRepositoryTest {
 	class Describe_findByIdAndUserIdWithProcess {
 
 		private final Long userId = 0L;
-
-		private ApplicationJpaEntity naverApplication;
-
-		@BeforeEach
-		void setUp() {
-			naverApplication = applicationRepository.save(
-				convertToApplicationEntity(userId, NAVER_APPLICATION.toDomain()));
-		}
-
-		@DisplayName("등록된 전형 과정이 없을 경우에도")
-		@Nested
-		class Context_with_no_process {
-
-			@DisplayName("지원서를 반환한다.")
-			@Test
-			void it_returns_optional_empty() {
-				Optional<ApplicationJpaEntity> response = applicationRepository.findByIdAndUserIdWithProcess(
-					naverApplication.getId(), userId);
-
-				assertThat(response).isNotEmpty();
-			}
-		}
+		private ApplicationJpaEntity naverApplicationEntity;
 
 		@DisplayName("지원서가 여러 프로세스를 갖고 있을 경우")
 		@Nested
 		class Context_with_many_processes {
 
-			private List<ApplicationProcessJpaEntity> naverProcesses;
+			private List<ApplicationProcessJpaEntity> naverProcessEntities;
 
 			@BeforeEach
 			void setUp() {
-				ApplicationProcessJpaEntity toApply = applicationProcessRepository.save(
-					convertToApplicationProcessEntity(naverApplication, TO_APPLY.toDomain()));
+				Application naverApplication = NAVER_APPLICATION.toDomain(TO_APPLY, DOCUMENT, TEST, INTERVIEW);
 
-				ApplicationProcessJpaEntity test = applicationProcessRepository.save(
-					convertToApplicationProcessEntity(naverApplication, TEST.toDomain()));
-
-				ApplicationProcessJpaEntity interview = applicationProcessRepository.save(
-					convertToApplicationProcessEntity(naverApplication, INTERVIEW.toDomain()));
-
-				naverProcesses = List.of(toApply, test, interview);
+				naverApplicationEntity = saveApplicationAndProcesses(userId, naverApplication);
+				naverProcessEntities = naverApplicationEntity.getProcesses();
 
 				entityManager.clear();
 			}
@@ -95,10 +69,12 @@ class ApplicationRepositoryTest {
 			@Test
 			void it_returns_application_with_processes() {
 				Optional<ApplicationJpaEntity> response = applicationRepository.findByIdAndUserIdWithProcess(
-					naverApplication.getId(), userId);
+					naverApplicationEntity.getId(), userId);
 
-				assertAll(() -> assertThat(response).isNotEmpty(),
-					() -> assertThat(response.get().getProcesses()).hasSize(naverProcesses.size()));
+				assertAll(
+					() -> assertThat(response).isNotEmpty(),
+					() -> assertThat(response.get().getProcesses()).hasSize(naverProcessEntities.size())
+				);
 			}
 		}
 
@@ -108,14 +84,17 @@ class ApplicationRepositoryTest {
 
 			@BeforeEach
 			void setUp() {
-				naverApplication.changeToDelete();
+				Application naverApplication = NAVER_APPLICATION.toDomain();
+				naverApplicationEntity = saveApplicationAndProcesses(userId, naverApplication);
+
+				naverApplicationEntity.changeToDelete();
 			}
 
 			@DisplayName("비어있는 결과를 반환한다.")
 			@Test
 			void it_returns_optional_empty() {
 				Optional<ApplicationJpaEntity> response = applicationRepository.findByIdAndUserIdWithProcess(
-					naverApplication.getId(), userId);
+					naverApplicationEntity.getId(), userId);
 
 				assertThat(response).isEmpty();
 			}
@@ -130,37 +109,28 @@ class ApplicationRepositoryTest {
 		private final int year = 2023;
 		private final int month = 9;
 
-		private ApplicationJpaEntity naverApplication;
-		private ApplicationJpaEntity kakaoApplication;
-
-		@BeforeEach
-		void setUp() {
-			naverApplication = applicationRepository.save(
-				convertToApplicationEntity(userId, NAVER_APPLICATION.toDomain()));
-			kakaoApplication = applicationRepository.save(
-				convertToApplicationEntity(userId, KAKAO_APPLICATION.toDomain()));
-		}
+		private ApplicationJpaEntity naverApplicationEntity;
+		private ApplicationJpaEntity kakaoApplicationEntity;
 
 		@DisplayName("여러 유저의 공고가 존재하여도")
 		@Nested
 		class Context_with_many_user_applications {
 
 			private final Long otherUserId = -1L;
-			private ApplicationJpaEntity otherUserApplication;
 
 			@BeforeEach
 			void setUp() {
-				otherUserApplication = applicationRepository.save(
-					convertToApplicationEntity(otherUserId, NAVER_APPLICATION.toDomain()));
+				Application naverApplication = NAVER_APPLICATION.toDomain(
+					TEST.toDomainWithSchedule(LocalDate.of(year, month, 11)));
+				naverApplicationEntity = saveApplicationAndProcesses(userId, naverApplication);
 
-				applicationProcessRepository.save(convertToApplicationProcessEntity(naverApplication,
-					TO_APPLY.toDomainWithSchedule(LocalDate.of(year, month, 11))));
+				Application kakoaApplication = KAKAO_APPLICATION.toDomain(
+					TEST.toDomainWithSchedule(LocalDate.of(year, month, 20)));
+				kakaoApplicationEntity = saveApplicationAndProcesses(userId, kakoaApplication);
 
-				applicationProcessRepository.save(convertToApplicationProcessEntity(kakaoApplication,
-					TO_APPLY.toDomainWithSchedule(LocalDate.of(year, month, 20))));
-
-				applicationProcessRepository.save(convertToApplicationProcessEntity(otherUserApplication,
-					TO_APPLY.toDomainWithSchedule(LocalDate.of(year, month, 11))));
+				Application otherUserApplication = COUPANG_APPLICATION.toDomain(
+					TEST.toDomainWithSchedule(LocalDate.of(year, month, 20)));
+				saveApplicationAndProcesses(otherUserId, otherUserApplication);
 			}
 
 			@DisplayName("특정 유저의 데이터만 반환한다.")
@@ -168,7 +138,7 @@ class ApplicationRepositoryTest {
 			void it_returns_only_data_for_a_specific_user() {
 				List<ApplicationJpaEntity> actual = applicationRepository.findByUserIdAndMonth(userId, year, month);
 
-				assertThat(actual).containsOnly(naverApplication, kakaoApplication);
+				assertThat(actual).containsOnly(naverApplicationEntity, kakaoApplicationEntity);
 			}
 		}
 
@@ -177,22 +147,18 @@ class ApplicationRepositoryTest {
 		class Context_with_many_schedules_for_several_months {
 
 			private final int otherMonth = 10;
-			private final List<ApplicationProcessJpaEntity> expectedProcesses = new ArrayList<>();
+			private int expectedNumOfProcesses;
 
 			@BeforeEach
 			void setUp() {
-				ApplicationProcessJpaEntity expectedProcess1 = applicationProcessRepository.save(
-					convertToApplicationProcessEntity(naverApplication,
-						TO_APPLY.toDomainWithSchedule(LocalDate.of(year, month, 11))));
+				Application kakoaApplication = KAKAO_APPLICATION.toDomain(
+					TEST.toDomainWithSchedule(LocalDate.of(year, month, 10)),
+					FIRST_INTERVIEW.toDomainWithSchedule(LocalDate.of(year, month, 20)),
+					SECOND_INTERVIEW.toDomainWithSchedule(LocalDate.of(year, otherMonth, 20)));
+				kakaoApplicationEntity = saveApplicationAndProcesses(userId, kakoaApplication);
 
-				ApplicationProcessJpaEntity expectedProcess2 = applicationProcessRepository.save(
-					convertToApplicationProcessEntity(kakaoApplication,
-						TO_APPLY.toDomainWithSchedule(LocalDate.of(year, month, 20))));
-
-				applicationProcessRepository.save(convertToApplicationProcessEntity(kakaoApplication,
-					TEST.toDomainWithSchedule(LocalDate.of(year, otherMonth, 20))));
-
-				expectedProcesses.addAll(List.of(expectedProcess1, expectedProcess2));
+				// TEST & FIRST_INTERVIEW
+				expectedNumOfProcesses = 2;
 
 				entityManager.clear();
 			}
@@ -207,7 +173,7 @@ class ApplicationRepositoryTest {
 					actualProcesses.addAll(application.getProcesses());
 				}
 
-				assertThat(actualProcesses).hasSize(expectedProcesses.size());
+				assertThat(actualProcesses).hasSize(expectedNumOfProcesses);
 			}
 		}
 
@@ -215,19 +181,17 @@ class ApplicationRepositoryTest {
 		@Nested
 		class Context_with_application_that_has_two_processes {
 
-			private final List<ApplicationProcessJpaEntity> expectedProcesses = new ArrayList<>();
+			private int expectedNumOfProcesses;
 
 			@BeforeEach
 			void setUp() {
-				ApplicationProcessJpaEntity expectedProcess1 = applicationProcessRepository.save(
-					convertToApplicationProcessEntity(naverApplication,
-						TO_APPLY.toDomainWithSchedule(LocalDate.of(year, month, 11))));
+				Application naverApplication = NAVER_APPLICATION.toDomain(
+					TEST.toDomainWithSchedule(LocalDate.of(year, month, 11)),
+					INTERVIEW.toDomainWithSchedule(LocalDate.of(year, month, 20)));
+				naverApplicationEntity = saveApplicationAndProcesses(userId, naverApplication);
 
-				ApplicationProcessJpaEntity expectedProcess2 = applicationProcessRepository.save(
-					convertToApplicationProcessEntity(naverApplication,
-						DOCUMENT.toDomainWithSchedule(LocalDate.of(year, month, 20))));
-
-				expectedProcesses.addAll(List.of(expectedProcess1, expectedProcess2));
+				// TEST & INTERVIEW
+				expectedNumOfProcesses = 2;
 
 				entityManager.clear();
 			}
@@ -238,7 +202,7 @@ class ApplicationRepositoryTest {
 				List<ApplicationJpaEntity> response = applicationRepository.findByUserIdAndMonth(userId, year, month);
 				List<ApplicationProcessJpaEntity> actual = response.get(0).getProcesses();
 
-				assertThat(actual).hasSize(expectedProcesses.size());
+				assertThat(actual).hasSize(expectedNumOfProcesses);
 			}
 		}
 	}
@@ -250,16 +214,8 @@ class ApplicationRepositoryTest {
 		private final Long userId = 1L;
 		private final LocalDate date = LocalDate.of(2023, 9, 13);
 
-		private ApplicationJpaEntity naverApplication;
-		private ApplicationJpaEntity kakaoApplication;
-
-		@BeforeEach
-		void setUp() {
-			naverApplication = applicationRepository.save(
-				convertToApplicationEntity(userId, NAVER_APPLICATION.toDomain()));
-			kakaoApplication = applicationRepository.save(
-				convertToApplicationEntity(userId, KAKAO_APPLICATION.toDomain()));
-		}
+		private ApplicationJpaEntity naverApplicationEntity;
+		private ApplicationJpaEntity kakaoApplicationEntity;
 
 		@DisplayName("해당 일이 전형일인 지원 전형이 있으면")
 		@Nested
@@ -267,11 +223,11 @@ class ApplicationRepositoryTest {
 
 			@BeforeEach
 			void setUp() {
-				applicationProcessRepository.save(
-					convertToApplicationProcessEntity(naverApplication, DOCUMENT.toDomainWithSchedule(date)));
+				Application naverApplication = NAVER_APPLICATION.toDomain(TEST.toDomainWithSchedule(date));
+				naverApplicationEntity = saveApplicationAndProcesses(userId, naverApplication);
 
-				applicationProcessRepository.save(
-					convertToApplicationProcessEntity(kakaoApplication, INTERVIEW.toDomainWithSchedule(date)));
+				Application kakoaApplication = KAKAO_APPLICATION.toDomain(TEST.toDomainWithSchedule(date));
+				kakaoApplicationEntity = saveApplicationAndProcesses(userId, kakoaApplication);
 
 				entityManager.clear();
 			}
@@ -281,7 +237,7 @@ class ApplicationRepositoryTest {
 			@ValueSource(longs = {0L, 1L})
 			void it_returns_applications_with_proper_processes(long day) {
 				// given
-				applicationProcessRepository.save(convertToApplicationProcessEntity(naverApplication,
+				applicationProcessRepository.save(convertToApplicationProcessEntity(naverApplicationEntity,
 					TEST.toDomainWithSchedule(date.plusDays(day))));    // day = 0일 때는 반환할 전형이 추가
 
 				// when
@@ -290,13 +246,13 @@ class ApplicationRepositoryTest {
 
 				ApplicationJpaEntity actualNaverApplication = applicationJpaEntities.stream()
 					.filter(applicationJpaEntity -> applicationJpaEntity.getCompanyName()
-						.equals(naverApplication.getCompanyName()))
+						.equals(naverApplicationEntity.getCompanyName()))
 					.findAny()
 					.orElseThrow();
 
 				ApplicationJpaEntity actualKakaoApplication = applicationJpaEntities.stream()
 					.filter(applicationJpaEntity -> applicationJpaEntity.getCompanyName()
-						.equals(kakaoApplication.getCompanyName()))
+						.equals(kakaoApplicationEntity.getCompanyName()))
 					.findAny()
 					.orElseThrow();
 
@@ -319,7 +275,7 @@ class ApplicationRepositoryTest {
 		@Nested
 		class Context_exist_processes_without_schedule {
 
-			@DisplayName("해당 전형들을 포함한 어플리케이션을 반환한다")
+			@DisplayName("전형일이 등록되어있지 않은 현재 전형만을 포함한 어플리케이션을 반환한다")
 			@Test
 			void it_return_applications_with_process() {
 				// given
@@ -327,21 +283,13 @@ class ApplicationRepositoryTest {
 				PageRequest pageRequest = PageRequest.of(0, 10);
 
 				int applicationCount = 1;
-				int processCount = 2;
 				for (int i = 0; i < applicationCount; i++) {
-					ApplicationJpaEntity applicationJpaEntity = applicationRepository.save(
-						convertToApplicationEntity(userId, NAVER_APPLICATION.toDomain())
+					Application naverApplication = NAVER_APPLICATION.toDomain(
+						TEST.toDomainWithSchedule((LocalDateTime)null),
+						FIRST_INTERVIEW.toDomainWithSchedule((LocalDateTime)null),
+						SECOND_INTERVIEW.toDomainWithSchedule((LocalDateTime)null)
 					);
-
-					for (int j = 1; j <= processCount; j++) {
-						Process process = TO_APPLY.toDomainWithScheduleAndOrder(null, j);
-						applicationProcessRepository.save(ApplicationProcessJpaEntity.of(
-							applicationJpaEntity, process));
-					}
-
-					Process process = DOCUMENT.toDomain();
-					applicationProcessRepository.save(ApplicationProcessJpaEntity.of(
-						applicationJpaEntity, process));
+					saveApplicationAndProcesses(userId, naverApplication);
 				}
 				entityManager.clear();
 
@@ -353,46 +301,6 @@ class ApplicationRepositoryTest {
 				assertAll(
 					() -> assertThat(applications.getNumberOfElements()).isEqualTo(applicationCount),
 					() -> assertThat(applications.getContent().get(0).getProcesses()).hasSize(1)
-				);
-			}
-		}
-
-		@DisplayName("전형일이 작성되어 있지 않으며, 현재 전형단계 이전의 프로세스들이 있을 때")
-		@Nested
-		class Context_exist_processes_before_current_process {
-
-			@DisplayName("해당 전형들을 제외한 어플리케이션이 반환된다")
-			@Test
-			void it_not_return() {
-				// given
-				Long userId = 1L;
-				PageRequest pageRequest = PageRequest.of(0, 10);
-
-				int applicationCount = 1;
-				int processCount = 2;
-				int currentProcessOrder = 1;
-				for (int i = 0; i < applicationCount; i++) {
-					ApplicationJpaEntity applicationJpaEntity = applicationRepository.save(
-						convertToApplicationEntity(userId, NAVER_APPLICATION.toDomain(), currentProcessOrder)
-					);
-
-					for (int j = 0; j < processCount; j++) {
-						Process process = TO_APPLY.toDomainWithScheduleAndOrder(null, j);
-						applicationProcessRepository.save(ApplicationProcessJpaEntity.of(
-							applicationJpaEntity, process));
-					}
-				}
-				entityManager.clear();
-
-				// when
-				Slice<ApplicationJpaEntity> applications = applicationRepository.findUnscheduledByUserId(userId,
-					pageRequest);
-
-				// then
-				assertAll(
-					() -> assertThat(applications.getNumberOfElements()).isEqualTo(applicationCount),
-					() -> assertThat(applications.getContent().get(0).getProcesses()).hasSize(
-						processCount - currentProcessOrder)
 				);
 			}
 		}
@@ -411,14 +319,8 @@ class ApplicationRepositoryTest {
 			void it_return_application_current_process() {
 				// given
 				Long userId = 1L;
-				ApplicationJpaEntity naverApplication = applicationRepository.save(
-					convertToApplicationEntity(userId, NAVER_APPLICATION.toDomain()));
-
-				applicationProcessRepository.save(
-					convertToApplicationProcessEntity(naverApplication, TO_APPLY.toDomain()));
-
-				applicationProcessRepository.save(
-					convertToApplicationProcessEntity(naverApplication, DOCUMENT.toDomain()));
+				Application naverApplication = NAVER_APPLICATION.toDomain(TO_APPLY, DOCUMENT);
+				saveApplicationAndProcesses(userId, naverApplication);
 				entityManager.clear();
 
 				// when
@@ -464,9 +366,24 @@ class ApplicationRepositoryTest {
 				application.getLocation(), application.getContact(), application.getPosition(),
 				application.getSpecificPosition(), application.getJobDescription(), application.getWorkType(),
 				application.getEmploymentType(), application.getCareerRequirement(),
-				application.getRequiredCapability(),
-				application.getPreferredQualification(), application.getUrl(), 0, null, null, deleted
+				application.getRequiredCapability(), application.getPreferredQualification(), application.getUrl(),
+				application.getCurrentProcess().getType(), application.getCurrentProcess().getOrder(), null, null,
+				deleted
 			);
 		}
+	}
+
+	public ApplicationJpaEntity saveApplicationAndProcesses(Long userId, Application application) {
+		ApplicationJpaEntity applicationEntity = applicationRepository.save(
+			convertToApplicationEntity(userId, application));
+
+		for (Process process : application.getProcesses()) {
+			ApplicationProcessJpaEntity applicationProcessJpaEntity = applicationProcessRepository.save(
+				convertToApplicationProcessEntity(applicationEntity, process));
+
+			applicationEntity.addProcess(applicationProcessJpaEntity);
+		}
+
+		return applicationEntity;
 	}
 }

--- a/out-adapter-persistence-jpa/src/test/java/gohigher/application/entity/ApplicationRepositoryTest.java
+++ b/out-adapter-persistence-jpa/src/test/java/gohigher/application/entity/ApplicationRepositoryTest.java
@@ -238,7 +238,7 @@ class ApplicationRepositoryTest {
 			void it_returns_applications_with_proper_processes(long day) {
 				// given
 				applicationProcessRepository.save(convertToApplicationProcessEntity(naverApplicationEntity,
-					TEST.toDomainWithSchedule(date.plusDays(day))));    // day = 0일 때는 반환할 전형이 추가
+					TEST.toDomainWithSchedule(date.plusDays(day)), true));    // day = 0일 때는 반환할 전형이 추가
 
 				// when
 				List<ApplicationJpaEntity> applicationJpaEntities = applicationRepository.findByUserIdAndDate(userId,
@@ -367,8 +367,7 @@ class ApplicationRepositoryTest {
 				application.getSpecificPosition(), application.getJobDescription(), application.getWorkType(),
 				application.getEmploymentType(), application.getCareerRequirement(),
 				application.getRequiredCapability(), application.getPreferredQualification(), application.getUrl(),
-				application.getCurrentProcess().getType(), application.getCurrentProcess().getOrder(), null, null,
-				deleted
+				null, null, deleted
 			);
 		}
 	}
@@ -379,7 +378,8 @@ class ApplicationRepositoryTest {
 
 		for (Process process : application.getProcesses()) {
 			ApplicationProcessJpaEntity applicationProcessJpaEntity = applicationProcessRepository.save(
-				convertToApplicationProcessEntity(applicationEntity, process));
+				convertToApplicationProcessEntity(applicationEntity, process,
+					application.getCurrentProcess() == process));
 
 			applicationEntity.addProcess(applicationProcessJpaEntity);
 		}

--- a/out-adapter-persistence-jpa/src/test/java/gohigher/fixtureConverter/ApplicationFixtureConverter.java
+++ b/out-adapter-persistence-jpa/src/test/java/gohigher/fixtureConverter/ApplicationFixtureConverter.java
@@ -13,27 +13,21 @@ import lombok.NoArgsConstructor;
 public class ApplicationFixtureConverter {
 
 	public static ApplicationJpaEntity convertToApplicationEntity(Long userId, Application application) {
-		return createApplicationJpaEntity(userId, application, 1);
+		return createApplicationJpaEntity(userId, application);
 	}
 
-	public static ApplicationJpaEntity convertToApplicationEntity(Long userId, Application application,
-		int currentProcessOrder) {
-		return createApplicationJpaEntity(userId, application, currentProcessOrder);
+	private static ApplicationJpaEntity createApplicationJpaEntity(
+		Long userId, Application application) {
+		return new ApplicationJpaEntity(null, userId, application.getCompanyName(), application.getTeam(),
+			application.getLocation(), application.getContact(), application.getPosition(),
+			application.getSpecificPosition(), application.getJobDescription(), application.getWorkType(),
+			application.getEmploymentType(), application.getCareerRequirement(), application.getRequiredCapability(),
+			application.getPreferredQualification(), application.getUrl(), application.getCurrentProcess().getType(),
+			application.getCurrentProcess().getOrder(), new ArrayList<>(), null, false);
 	}
 
 	public static ApplicationProcessJpaEntity convertToApplicationProcessEntity(
 		ApplicationJpaEntity applicationJpaEntity, Process process) {
 		return ApplicationProcessJpaEntity.of(applicationJpaEntity, process);
-	}
-
-	private static ApplicationJpaEntity createApplicationJpaEntity(
-		Long userId, Application application, int currentProcessOrder
-	) {
-		return new ApplicationJpaEntity(null, userId, application.getCompanyName(), application.getTeam(),
-			application.getLocation(), application.getContact(), application.getPosition(),
-			application.getSpecificPosition(), application.getJobDescription(), application.getWorkType(),
-			application.getEmploymentType(), application.getCareerRequirement(), application.getRequiredCapability(),
-			application.getPreferredQualification(), application.getUrl(), currentProcessOrder, new ArrayList<>(),
-			null, false);
 	}
 }

--- a/out-adapter-persistence-jpa/src/test/java/gohigher/fixtureConverter/ApplicationFixtureConverter.java
+++ b/out-adapter-persistence-jpa/src/test/java/gohigher/fixtureConverter/ApplicationFixtureConverter.java
@@ -22,12 +22,16 @@ public class ApplicationFixtureConverter {
 			application.getLocation(), application.getContact(), application.getPosition(),
 			application.getSpecificPosition(), application.getJobDescription(), application.getWorkType(),
 			application.getEmploymentType(), application.getCareerRequirement(), application.getRequiredCapability(),
-			application.getPreferredQualification(), application.getUrl(), application.getCurrentProcess().getType(),
-			application.getCurrentProcess().getOrder(), new ArrayList<>(), null, false);
+			application.getPreferredQualification(), application.getUrl(), new ArrayList<>(), null, false);
 	}
 
 	public static ApplicationProcessJpaEntity convertToApplicationProcessEntity(
-		ApplicationJpaEntity applicationJpaEntity, Process process) {
-		return ApplicationProcessJpaEntity.of(applicationJpaEntity, process);
+		ApplicationJpaEntity applicationJpaEntity, Process process, boolean isCurrent) {
+		return ApplicationProcessJpaEntity.of(applicationJpaEntity, process, isCurrent);
+	}
+
+	public static ApplicationProcessJpaEntity convertToApplicationProcessEntity(
+		ApplicationJpaEntity applicationJpaEntity, Process process, Process currentProcess) {
+		return convertToApplicationProcessEntity(applicationJpaEntity, process, currentProcess == process);
 	}
 }


### PR DESCRIPTION
## 작업 내용
- 정책 변경에 따라 Process의 Order를 ProcessType별로 관리하도록 변경
- JPA Entity에 currentProcessType필드 추가
- 현재 전형과 관련된 조회 로직 조건에 currentProcessType의 비교 조건 추가
- 현재 전형 변경 로직 수정
- 테스트 코드에서 Process가 하나도 없거나 CurrentProcess정보에 무의미한 값(null or Invalid Index)이 들어간 불완전한 객체가 없도록 전반적인 테스트 코드 수정
- entity에서 현재 Process정보를 ProcessEntity에서 하도록 변경

## 추가로 정한 후, 적용할 내용
- 지원서 상세 등록시 현재 프로세스의 정보를 어떻게 받아와서 설정할지에 대해 이야기해보면 좋겠습니다.
   - 현재는 아래의 코드와 같이 첫번째 프로세스를 현재 프로세스로 설정된 상태입니다.
```java
	public Application toDomain() {
		List<Process> processes = this.processes.stream()
			.map(SpecificApplicationProcessRequest::toDomain)
			.toList();

		return new Application(null, companyName, team, location, contact, position, specificPosition, jobDescription,
			workType, EmploymentType.from(employmentType), careerRequirement, requiredCapability,
			preferredQualification, Processes.initialFrom(processes), url, processes.get(0));
	}
```

resolve #125 
