### PR TITLE
[FEATURE] 칸반 새로운 전형 추가 API

### DIFF
--- a/core-application/src/main/java/gohigher/application/port/in/ApplicationProcessByProcessTypeResponse.java
+++ b/core-application/src/main/java/gohigher/application/port/in/ApplicationProcessByProcessTypeResponse.java
@@ -1,9 +1,6 @@
 package gohigher.application.port.in;
 
-import java.time.LocalDateTime;
-
 import gohigher.common.Process;
-import gohigher.common.ProcessType;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -12,10 +9,9 @@ import lombok.RequiredArgsConstructor;
 public class ApplicationProcessByProcessTypeResponse {
 
 	private final long id;
-	private final ProcessType type;
-	private final LocalDateTime schedule;
+	private final String description;
 
 	public static ApplicationProcessByProcessTypeResponse from(Process process) {
-		return new ApplicationProcessByProcessTypeResponse(process.getId(), process.getType(), process.getSchedule());
+		return new ApplicationProcessByProcessTypeResponse(process.getId(), process.getDescription());
 	}
 }

--- a/core-application/src/main/java/gohigher/application/port/in/ApplicationProcessCommandPort.java
+++ b/core-application/src/main/java/gohigher/application/port/in/ApplicationProcessCommandPort.java
@@ -3,5 +3,5 @@ package gohigher.application.port.in;
 public interface ApplicationProcessCommandPort {
 
 	ApplicationProcessByProcessTypeResponse register(Long userId, long applicationId,
-		SimpleApplicationProcessRequest request);
+		UnscheduledProcessRequest request);
 }

--- a/core-application/src/main/java/gohigher/application/port/in/ApplicationProcessCommandPort.java
+++ b/core-application/src/main/java/gohigher/application/port/in/ApplicationProcessCommandPort.java
@@ -1,0 +1,7 @@
+package gohigher.application.port.in;
+
+public interface ApplicationProcessCommandPort {
+
+	ApplicationProcessByProcessTypeResponse register(Long userId, long applicationId,
+		SimpleApplicationProcessRequest request);
+}

--- a/core-application/src/main/java/gohigher/application/port/in/SimpleApplicationProcessRequest.java
+++ b/core-application/src/main/java/gohigher/application/port/in/SimpleApplicationProcessRequest.java
@@ -5,12 +5,13 @@ import java.time.LocalDateTime;
 import gohigher.common.Process;
 import gohigher.common.ProcessType;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class SimpleApplicationProcessRequest {
 
 	@NotBlank(message = "JOB_INFO_005||전형 단계가 입력되지 않았습니다.")

--- a/core-application/src/main/java/gohigher/application/port/in/UnscheduledProcessRequest.java
+++ b/core-application/src/main/java/gohigher/application/port/in/UnscheduledProcessRequest.java
@@ -1,0 +1,24 @@
+package gohigher.application.port.in;
+
+import gohigher.common.Process;
+import gohigher.common.ProcessType;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UnscheduledProcessRequest {
+
+	@NotBlank(message = "JOB_INFO_005||전형 단계가 입력되지 않았습니다.")
+	private String type;
+
+	@NotBlank(message = "JOB_INFO_006||세부 전형이 입력되지 않았습니다.")
+	private String description;
+
+	public Process toDomain() {
+		return new Process(null, ProcessType.from(type), description, null);
+	}
+}

--- a/core-application/src/main/java/gohigher/application/port/out/persistence/ApplicationProcessPersistenceCommandPort.java
+++ b/core-application/src/main/java/gohigher/application/port/out/persistence/ApplicationProcessPersistenceCommandPort.java
@@ -1,0 +1,8 @@
+package gohigher.application.port.out.persistence;
+
+import gohigher.common.Process;
+
+public interface ApplicationProcessPersistenceCommandPort {
+
+	Process save(long applicationId, Process process);
+}

--- a/core-application/src/main/java/gohigher/application/port/out/persistence/ApplicationProcessPersistenceQueryPort.java
+++ b/core-application/src/main/java/gohigher/application/port/out/persistence/ApplicationProcessPersistenceQueryPort.java
@@ -7,7 +7,7 @@ import gohigher.common.ProcessType;
 
 public interface ApplicationProcessPersistenceQueryPort {
 
-    boolean existsById(Long id);
+	boolean existsById(Long id);
 
-    List<Process> findByApplicationIdAndProcessType(Long applicationId, ProcessType processType);
+	List<Process> findByApplicationIdAndProcessType(Long applicationId, ProcessType processType);
 }

--- a/core-application/src/main/java/gohigher/application/service/ApplicationProcessCommandService.java
+++ b/core-application/src/main/java/gohigher/application/service/ApplicationProcessCommandService.java
@@ -8,7 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import gohigher.application.ApplicationErrorCode;
 import gohigher.application.port.in.ApplicationProcessByProcessTypeResponse;
 import gohigher.application.port.in.ApplicationProcessCommandPort;
-import gohigher.application.port.in.SimpleApplicationProcessRequest;
+import gohigher.application.port.in.UnscheduledProcessRequest;
 import gohigher.application.port.out.persistence.ApplicationPersistenceQueryPort;
 import gohigher.application.port.out.persistence.ApplicationProcessPersistenceCommandPort;
 import gohigher.application.port.out.persistence.ApplicationProcessPersistenceQueryPort;
@@ -28,7 +28,7 @@ public class ApplicationProcessCommandService implements ApplicationProcessComma
 
 	@Override
 	public ApplicationProcessByProcessTypeResponse register(Long userId, long applicationId,
-		SimpleApplicationProcessRequest request) {
+		UnscheduledProcessRequest request) {
 		validateAuthorizationOfUser(userId, applicationId);
 
 		ProcessType type = ProcessType.valueOf(request.getType());

--- a/core-application/src/main/java/gohigher/application/service/ApplicationProcessCommandService.java
+++ b/core-application/src/main/java/gohigher/application/service/ApplicationProcessCommandService.java
@@ -1,0 +1,58 @@
+package gohigher.application.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import gohigher.application.ApplicationErrorCode;
+import gohigher.application.port.in.ApplicationProcessByProcessTypeResponse;
+import gohigher.application.port.in.ApplicationProcessCommandPort;
+import gohigher.application.port.in.SimpleApplicationProcessRequest;
+import gohigher.application.port.out.persistence.ApplicationPersistenceQueryPort;
+import gohigher.application.port.out.persistence.ApplicationProcessPersistenceCommandPort;
+import gohigher.application.port.out.persistence.ApplicationProcessPersistenceQueryPort;
+import gohigher.common.Process;
+import gohigher.common.ProcessType;
+import gohigher.global.exception.GoHigherException;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ApplicationProcessCommandService implements ApplicationProcessCommandPort {
+
+	private final ApplicationPersistenceQueryPort applicationPersistenceQueryPort;
+	private final ApplicationProcessPersistenceCommandPort applicationProcessPersistenceCommandPort;
+	private final ApplicationProcessPersistenceQueryPort applicationProcessPersistenceQueryPort;
+
+	@Override
+	public ApplicationProcessByProcessTypeResponse register(Long userId, long applicationId,
+		SimpleApplicationProcessRequest request) {
+		validateAuthorizationOfUser(userId, applicationId);
+
+		ProcessType type = ProcessType.valueOf(request.getType());
+		Process process = makeNewProcess(applicationId, type, request.getDescription());
+		Process savedProcess = applicationProcessPersistenceCommandPort.save(applicationId, process);
+		return ApplicationProcessByProcessTypeResponse.from(savedProcess);
+	}
+
+	private void validateAuthorizationOfUser(Long userId, Long applicationId) {
+		if (!applicationPersistenceQueryPort.existsByIdAndUserId(applicationId, userId)) {
+			throw new GoHigherException(ApplicationErrorCode.APPLICATION_NOT_FOUND);
+		}
+	}
+
+	private Process makeNewProcess(long applicationId, ProcessType type, String description) {
+		List<Process> applicationProcessesByType = applicationProcessPersistenceQueryPort.findByApplicationIdAndProcessType(
+			applicationId, type);
+
+		if (applicationProcessesByType.isEmpty()) {
+			return Process.makeFirstByType(type, description);
+		}
+
+		Process lastProcess = applicationProcessesByType.get(applicationProcessesByType.size() - 1);
+		return new Process(type, description, null, lastProcess.getOrder() + 1);
+	}
+}
+

--- a/core-application/src/main/java/gohigher/application/service/ApplicationProcessQueryService.java
+++ b/core-application/src/main/java/gohigher/application/service/ApplicationProcessQueryService.java
@@ -1,7 +1,6 @@
 package gohigher.application.service;
 
 import java.util.List;
-import java.util.Objects;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/core-application/src/test/java/gohigher/application/service/ApplicationCommandServiceTest.java
+++ b/core-application/src/test/java/gohigher/application/service/ApplicationCommandServiceTest.java
@@ -24,12 +24,16 @@ class ApplicationCommandServiceTest {
 
 	private static final long APPLICATION_ID = 1L;
 	private final long applicationOwnerId = 1L;
+	
 	@Mock
 	private ApplicationPersistenceCommandPort applicationPersistenceCommandPort;
+
 	@Mock
 	private ApplicationPersistenceQueryPort applicationPersistenceQueryPort;
+
 	@Mock
 	private ApplicationProcessPersistenceQueryPort applicationProcessPersistenceQueryPort;
+
 	@InjectMocks
 	private ApplicationCommandService applicationCommandService;
 

--- a/core-application/src/test/java/gohigher/application/service/ApplicationProcessCommandServiceTest.java
+++ b/core-application/src/test/java/gohigher/application/service/ApplicationProcessCommandServiceTest.java
@@ -71,5 +71,4 @@ class ApplicationProcessCommandServiceTest {
 			}
 		}
 	}
-
 }

--- a/core-application/src/test/java/gohigher/application/service/ApplicationProcessCommandServiceTest.java
+++ b/core-application/src/test/java/gohigher/application/service/ApplicationProcessCommandServiceTest.java
@@ -14,7 +14,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import gohigher.application.port.in.ApplicationProcessByProcessTypeResponse;
-import gohigher.application.port.in.SimpleApplicationProcessRequest;
+import gohigher.application.port.in.UnscheduledProcessRequest;
 import gohigher.application.port.out.persistence.ApplicationPersistenceQueryPort;
 import gohigher.application.port.out.persistence.ApplicationProcessPersistenceCommandPort;
 import gohigher.application.port.out.persistence.ApplicationProcessPersistenceQueryPort;
@@ -56,11 +56,11 @@ class ApplicationProcessCommandServiceTest {
 				when(applicationPersistenceQueryPort.existsByIdAndUserId(userId, applicationId)).thenReturn(true);
 				when(applicationProcessPersistenceQueryPort.findByApplicationIdAndProcessType(applicationId, interview))
 					.thenReturn(new ArrayList<>());
-				SimpleApplicationProcessRequest interviewRequest = new SimpleApplicationProcessRequest(interview.name(),
-					"1차 면접", null);
+				UnscheduledProcessRequest interviewRequest = new UnscheduledProcessRequest(interview.name(),
+					"1차 면접");
 				when(applicationProcessPersistenceCommandPort.save(anyLong(), any())).thenReturn(
 					new Process(1L, interview, interviewRequest.getDescription(),
-						interviewRequest.getSchedule(), 1));
+						null, 1));
 
 				// when
 				ApplicationProcessByProcessTypeResponse response = applicationProcessCommandService.register(userId,

--- a/core-application/src/test/java/gohigher/application/service/ApplicationProcessCommandServiceTest.java
+++ b/core-application/src/test/java/gohigher/application/service/ApplicationProcessCommandServiceTest.java
@@ -1,0 +1,75 @@
+package gohigher.application.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import gohigher.application.port.in.ApplicationProcessByProcessTypeResponse;
+import gohigher.application.port.in.SimpleApplicationProcessRequest;
+import gohigher.application.port.out.persistence.ApplicationPersistenceQueryPort;
+import gohigher.application.port.out.persistence.ApplicationProcessPersistenceCommandPort;
+import gohigher.application.port.out.persistence.ApplicationProcessPersistenceQueryPort;
+import gohigher.common.Process;
+import gohigher.common.ProcessType;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ApplicationProcessCommandService 클래스의 ")
+class ApplicationProcessCommandServiceTest {
+
+	@Mock
+	private ApplicationPersistenceQueryPort applicationPersistenceQueryPort;
+
+	@Mock
+	private ApplicationProcessPersistenceCommandPort applicationProcessPersistenceCommandPort;
+
+	@Mock
+	private ApplicationProcessPersistenceQueryPort applicationProcessPersistenceQueryPort;
+
+	@InjectMocks
+	private ApplicationProcessCommandService applicationProcessCommandService;
+
+	@DisplayName("register 메서드는")
+	@Nested
+	class Describe_Register {
+
+		Long userId = 1L;
+		Long applicationId = 1L;
+
+		@DisplayName("새로운 전형 정보를 받았을 때,")
+		@Nested
+		class Context_Request_New_Process {
+
+			@DisplayName("기존에 해당 타입의 전형이 없다면 전형 정보를 저장하고 값을 리턴한다.")
+			@Test
+			void it_returns_saved_process() {
+				// given
+				ProcessType interview = ProcessType.INTERVIEW;
+				when(applicationPersistenceQueryPort.existsByIdAndUserId(userId, applicationId)).thenReturn(true);
+				when(applicationProcessPersistenceQueryPort.findByApplicationIdAndProcessType(applicationId, interview))
+					.thenReturn(new ArrayList<>());
+				SimpleApplicationProcessRequest interviewRequest = new SimpleApplicationProcessRequest(interview.name(),
+					"1차 면접", null);
+				when(applicationProcessPersistenceCommandPort.save(anyLong(), any())).thenReturn(
+					new Process(1L, interview, interviewRequest.getDescription(),
+						interviewRequest.getSchedule(), 1));
+
+				// when
+				ApplicationProcessByProcessTypeResponse response = applicationProcessCommandService.register(userId,
+					applicationId, interviewRequest);
+
+				// then
+				assertThat(response.getDescription()).isEqualTo(interviewRequest.getDescription());
+			}
+		}
+	}
+
+}

--- a/core-application/src/test/java/gohigher/application/service/ApplicationProcessQueryServiceTest.java
+++ b/core-application/src/test/java/gohigher/application/service/ApplicationProcessQueryServiceTest.java
@@ -23,8 +23,10 @@ class ApplicationProcessQueryServiceTest {
 
 	@Mock
 	private ApplicationPersistenceQueryPort applicationPersistenceQueryPort;
+
 	@Mock
 	private ApplicationProcessPersistenceQueryPort applicationProcessPersistenceQueryPort;
+
 	@InjectMocks
 	private ApplicationProcessQueryService applicationProcessQueryService;
 

--- a/core-application/src/test/java/gohigher/user/service/UserCommandServiceTest.java
+++ b/core-application/src/test/java/gohigher/user/service/UserCommandServiceTest.java
@@ -6,11 +6,11 @@ import static org.mockito.BDDMockito.*;
 
 import java.util.Optional;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -33,13 +33,8 @@ class UserCommandServiceTest {
 	@Mock
 	private DesiredPositionCommandPort desiredPositionCommandPort;
 
+	@InjectMocks
 	private UserCommandService userCommandService;
-
-	@BeforeEach
-	void setUp() {
-		userCommandService = new UserCommandService(userPersistenceQueryPort, userPersistenceCommandPort,
-			desiredPositionCommandPort);
-	}
 
 	@DisplayName("login 메서드는")
 	@Nested

--- a/core-domain/src/main/java/gohigher/common/JobInfoErrorCode.java
+++ b/core-domain/src/main/java/gohigher/common/JobInfoErrorCode.java
@@ -14,7 +14,6 @@ public enum JobInfoErrorCode implements ErrorCode {
 	INVALID_EMPLOYMENT_TYPE(400, "JOB_INFO_004", "유효하지 않은 고용 형태입니다."),
 	PROCESS_TYPE_BLANK(400, "JOB_INFO_005", "전형 단계가 입력되지 않았습니다."),
 	PROCESS_DESCRIPTION_BLANK(400, "JOB_INFO_006", "세부 전형이 입력되지 않았습니다."),
-	PROCESS_SCHEDULE_NULL(400, "JOB_INFO_007", "전형 일정이 입력되지 않았습니다."),
 	;
 
 	private final int statusCode;

--- a/core-domain/src/main/java/gohigher/common/Process.java
+++ b/core-domain/src/main/java/gohigher/common/Process.java
@@ -14,6 +14,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class Process {
 
+	private static final int INIT_ORDER = 1;
+
 	private final Long id;
 	private final ProcessType type;
 	private final String description;
@@ -27,6 +29,10 @@ public class Process {
 
 	public Process(Long id, ProcessType type, String description, LocalDateTime schedule) {
 		this(id, type, description, schedule, 0);
+	}
+
+	public static Process makeFirstByType(ProcessType type, String description) {
+		return new Process(type, description, null, INIT_ORDER);
 	}
 
 	public void assignOrder(int order) {

--- a/core-domain/src/test/java/gohigher/common/ProcessTest.java
+++ b/core-domain/src/test/java/gohigher/common/ProcessTest.java
@@ -1,0 +1,31 @@
+package gohigher.common;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Process 클래스의")
+class ProcessTest {
+
+	@DisplayName("makeFirstByType 메서드는")
+	@Nested
+	class Describe_makeFirstByType {
+
+		@DisplayName("세부 전형을 입력받으면")
+		@Nested
+		class Context_input_description {
+
+			@DisplayName("order가 1인 Process를 반환한다")
+			@Test
+			void it_returns_first_order_process() {
+				// given & when
+				Process process = Process.makeFirstByType(ProcessType.INTERVIEW, "1차 면접");
+
+				// then
+				assertThat(process.getOrder()).isEqualTo(1);
+			}
+		}
+	}
+}

--- a/in-adapter-api/src/main/java/gohigher/application/ApplicationCommandControllerDocs.java
+++ b/in-adapter-api/src/main/java/gohigher/application/ApplicationCommandControllerDocs.java
@@ -65,16 +65,6 @@ public interface ApplicationCommandControllerDocs {
 					},
 					"data": null
 					}
-					"""),
-				@ExampleObject(name = "전형 일정 입력되지 않음", value = """
-					{
-					"success": false,
-					"error": {
-						"code": "JOB_INFO_007",
-						"message": "전형 일정이 입력되지 않았습니다."
-					},
-					"data": null
-					}
 					""")
 			}))})
 	ResponseEntity<GohigherResponse<SimpleApplicationRegisterResponse>> registerApplicationSimply(

--- a/in-adapter-api/src/main/java/gohigher/application/ApplicationProcessCommandController.java
+++ b/in-adapter-api/src/main/java/gohigher/application/ApplicationProcessCommandController.java
@@ -1,0 +1,32 @@
+package gohigher.application;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import gohigher.application.port.in.ApplicationProcessByProcessTypeResponse;
+import gohigher.application.port.in.ApplicationProcessCommandPort;
+import gohigher.application.port.in.SimpleApplicationProcessRequest;
+import gohigher.auth.support.Login;
+import gohigher.controller.response.GohigherResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class ApplicationProcessCommandController {
+
+	private final ApplicationProcessCommandPort applicationProcessCommandPort;
+
+	@PostMapping("/v1/applications/{applicationId}/processes")
+	public ResponseEntity<GohigherResponse<ApplicationProcessByProcessTypeResponse>> registerApplicationProcess(
+		@Login Long userId, @PathVariable long applicationId,
+		@Valid @RequestBody SimpleApplicationProcessRequest request) {
+		ApplicationProcessByProcessTypeResponse response = applicationProcessCommandPort.register(userId, applicationId,
+			request);
+		return ResponseEntity.ok(GohigherResponse.success(response));
+	}
+
+}

--- a/in-adapter-api/src/main/java/gohigher/application/ApplicationProcessCommandController.java
+++ b/in-adapter-api/src/main/java/gohigher/application/ApplicationProcessCommandController.java
@@ -16,7 +16,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-public class ApplicationProcessCommandController {
+public class ApplicationProcessCommandController implements ApplicationProcessCommandControllerDocs {
 
 	private final ApplicationProcessCommandPort applicationProcessCommandPort;
 

--- a/in-adapter-api/src/main/java/gohigher/application/ApplicationProcessCommandController.java
+++ b/in-adapter-api/src/main/java/gohigher/application/ApplicationProcessCommandController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import gohigher.application.port.in.ApplicationProcessByProcessTypeResponse;
 import gohigher.application.port.in.ApplicationProcessCommandPort;
-import gohigher.application.port.in.SimpleApplicationProcessRequest;
+import gohigher.application.port.in.UnscheduledProcessRequest;
 import gohigher.auth.support.Login;
 import gohigher.controller.response.GohigherResponse;
 import jakarta.validation.Valid;
@@ -23,7 +23,7 @@ public class ApplicationProcessCommandController implements ApplicationProcessCo
 	@PostMapping("/v1/applications/{applicationId}/processes")
 	public ResponseEntity<GohigherResponse<ApplicationProcessByProcessTypeResponse>> registerApplicationProcess(
 		@Login Long userId, @PathVariable long applicationId,
-		@Valid @RequestBody SimpleApplicationProcessRequest request) {
+		@Valid @RequestBody UnscheduledProcessRequest request) {
 		ApplicationProcessByProcessTypeResponse response = applicationProcessCommandPort.register(userId, applicationId,
 			request);
 		return ResponseEntity.ok(GohigherResponse.success(response));

--- a/in-adapter-api/src/main/java/gohigher/application/ApplicationProcessCommandControllerDocs.java
+++ b/in-adapter-api/src/main/java/gohigher/application/ApplicationProcessCommandControllerDocs.java
@@ -1,0 +1,63 @@
+package gohigher.application;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import gohigher.application.port.in.ApplicationProcessByProcessTypeResponse;
+import gohigher.application.port.in.SimpleApplicationProcessRequest;
+import gohigher.controller.response.GohigherResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "지원서 전형")
+public interface ApplicationProcessCommandControllerDocs {
+
+	@Operation(summary = "전형 이동을 위한 새로운 전형 생성")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "전형 추가 성공"),
+		@ApiResponse(responseCode = "400", description = "전형 타입 및 세부 전형명 입력되지 않음", content = @Content(
+			examples = {
+				@ExampleObject(name = "전형 단계 입력되지 않음", value = """
+					{
+					"success": false,
+					"error": {
+						"code": "JOB_INFO_005",
+						"message": "전형 단계가 입력되지 않았습니다."
+					},
+					"data": null
+					}
+					"""),
+				@ExampleObject(name = "세부 전형 입력되지 않음", value = """
+					{
+					"success": false,
+					"error": {
+						"code": "JOB_INFO_006",
+						"message": "세부 전형이 입력되지 않았습니다."
+					},
+					"data": null
+					}
+					""")
+			})),
+		@ApiResponse(responseCode = "404", description = "지원서가 없는 경우", content = @Content(
+			examples = {
+				@ExampleObject(name = "지원서가 존재하지 않음", value = """
+					{
+					"success": false,
+					"error": {
+						"code": "APPLICATION_001",
+						"message": "존재하지 않는 지원서입니다."
+					},
+					"data": null
+					}
+					""")
+			}))
+	})
+	ResponseEntity<GohigherResponse<ApplicationProcessByProcessTypeResponse>> registerApplicationProcess(
+		@Parameter(hidden = true) Long userId, long applicationId,
+		@RequestBody SimpleApplicationProcessRequest request);
+}

--- a/in-adapter-api/src/main/java/gohigher/application/ApplicationProcessCommandControllerDocs.java
+++ b/in-adapter-api/src/main/java/gohigher/application/ApplicationProcessCommandControllerDocs.java
@@ -4,7 +4,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import gohigher.application.port.in.ApplicationProcessByProcessTypeResponse;
-import gohigher.application.port.in.SimpleApplicationProcessRequest;
+import gohigher.application.port.in.UnscheduledProcessRequest;
 import gohigher.controller.response.GohigherResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -59,5 +59,5 @@ public interface ApplicationProcessCommandControllerDocs {
 	})
 	ResponseEntity<GohigherResponse<ApplicationProcessByProcessTypeResponse>> registerApplicationProcess(
 		@Parameter(hidden = true) Long userId, long applicationId,
-		@RequestBody SimpleApplicationProcessRequest request);
+		@RequestBody UnscheduledProcessRequest request);
 }

--- a/out-adapter-persistence-jpa/src/main/java/gohigher/application/ApplicationProcessPersistenceCommandAdapter.java
+++ b/out-adapter-persistence-jpa/src/main/java/gohigher/application/ApplicationProcessPersistenceCommandAdapter.java
@@ -1,0 +1,27 @@
+package gohigher.application;
+
+import org.springframework.stereotype.Component;
+
+import gohigher.application.entity.ApplicationJpaEntity;
+import gohigher.application.entity.ApplicationProcessJpaEntity;
+import gohigher.application.entity.ApplicationProcessRepository;
+import gohigher.application.entity.ApplicationRepository;
+import gohigher.application.port.out.persistence.ApplicationProcessPersistenceCommandPort;
+import gohigher.common.Process;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ApplicationProcessPersistenceCommandAdapter implements ApplicationProcessPersistenceCommandPort {
+
+	private final ApplicationRepository applicationRepository;
+	private final ApplicationProcessRepository applicationProcessRepository;
+
+	@Override
+	public Process save(long applicationId, Process process) {
+		ApplicationJpaEntity application = applicationRepository.getReferenceById(applicationId);
+		ApplicationProcessJpaEntity applicationProcess = ApplicationProcessJpaEntity.of(application, process, false);
+		return applicationProcessRepository.save(applicationProcess)
+			.toDomain();
+	}
+}

--- a/out-adapter-persistence-jpa/src/test/java/gohigher/application/ApplicationProcessPersistenceCommandAdapterTest.java
+++ b/out-adapter-persistence-jpa/src/test/java/gohigher/application/ApplicationProcessPersistenceCommandAdapterTest.java
@@ -1,0 +1,88 @@
+package gohigher.application;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import gohigher.application.entity.ApplicationJpaEntity;
+import gohigher.application.entity.ApplicationProcessRepository;
+import gohigher.application.entity.ApplicationRepository;
+import gohigher.common.Process;
+import gohigher.common.ProcessType;
+import gohigher.user.UserFixture;
+import gohigher.user.entity.UserJpaEntity;
+import gohigher.user.entity.UserRepository;
+import jakarta.persistence.EntityManager;
+
+@DisplayName("ApplicationProcessPersistenceCommandAdapter 클래스의")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DataJpaTest
+class ApplicationProcessPersistenceCommandAdapterTest {
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private ApplicationRepository applicationRepository;
+
+	@Autowired
+	private ApplicationProcessRepository applicationProcessRepository;
+
+	private ApplicationProcessPersistenceCommandAdapter applicationProcessPersistenceCommandAdapter;
+
+	@Autowired
+	private EntityManager entityManager;
+
+	private Long userId;
+
+	@BeforeEach
+	void setUp() {
+		applicationProcessPersistenceCommandAdapter = new ApplicationProcessPersistenceCommandAdapter(
+			applicationRepository, applicationProcessRepository);
+		UserJpaEntity savedUser = userRepository.save(UserJpaEntity.from(UserFixture.AZPI.toDomain()));
+		userId = savedUser.getId();
+	}
+
+	@DisplayName("save 메서드는")
+	@Nested
+	class Describe_save {
+
+		private Long applicationId;
+
+		@BeforeEach
+		void setUp() {
+			Application kakao = ApplicationFixture.KAKAO_APPLICATION.toDomain(ProcessFixture.TEST);
+			ApplicationJpaEntity savedApplication = applicationRepository.save(ApplicationJpaEntity.of(kakao, userId));
+			applicationId = savedApplication.getId();
+			entityManager.clear();
+		}
+
+		@DisplayName("application_id와 Process 객체를 받으면")
+		@Nested
+		class Context_input_applicationId_and_Process {
+
+			@DisplayName("해당 정보를 저장하고 값을 리턴한다.")
+			@Test
+			void it_returns_saved_value() {
+				// given
+				Process newProcess = Process.makeFirstByType(ProcessType.INTERVIEW, "1차 면접");
+
+				// when
+				Process savedProcess = applicationProcessPersistenceCommandAdapter.save(applicationId, newProcess);
+
+				// then
+				assertAll(
+					() -> assertThat(savedProcess.getDescription()).isEqualTo(newProcess.getDescription()),
+					() -> assertThat(savedProcess.getId()).isNotNull()
+				);
+			}
+		}
+	}
+}


### PR DESCRIPTION
## 작업 내용
- 칸반에서 드래그 & 드랍 시 새로운 전형 추가를 원하면 사용하는 API를 구현한다.
- 해당 ProcessType의 마지막 order를 알기 위해 List를 application단으로 끌고와 찾는 방식입니다.
```
1. Persistence에서 order를 찾아오는 방식
2. Application에서 판단하는 방식
```
사실 DB에서 정보를 가져와 쓰면 편하고 빠르겠지만 해당 부분은 우리 서비스의 비즈니스 로직이라고 생각해서 application단에서 찾았습니다. 다른 의견있으시면 말씀부탁드려요!!

## 변경 내용
- 기존에 있던 칸 이동을 위한 해당 칸 모든 전형 추가에 `type -> description`으로 수정
- Swagger에서 정책상 필요없어진 에러 명세 삭제

resolve #137 
