### PR TITLE
[FEATURE] 지원서 삭제 API 기능 구현

### DIFF
--- a/bootstrap/src/test/java/gohigher/acceptance/AcceptanceTest.java
+++ b/bootstrap/src/test/java/gohigher/acceptance/AcceptanceTest.java
@@ -58,14 +58,20 @@ public class AcceptanceTest {
 		post(accessToken, "v1/desired-positions", desiredPositionRequest);
 	}
 
-	ValidatableResponse post(String accessToken, String uri, Object desiredPositionRequest) {
+	ValidatableResponse post(String accessToken, String uri, Object requestBody) {
 		return RestAssured.given().log().all()
 			.auth().oauth2(accessToken)
-			.body(desiredPositionRequest)
+			.body(requestBody)
 			.contentType(MediaType.APPLICATION_JSON_VALUE)
 			.accept(MediaType.APPLICATION_JSON_VALUE)
 			.when().post(uri)
 			.then().log().all();
 	}
 
+	ValidatableResponse delete(String accessToken, String uri) {
+		return RestAssured.given().log().all()
+			.auth().oauth2(accessToken)
+			.when().delete(uri)
+			.then().log().all();
+	}
 }

--- a/bootstrap/src/test/java/gohigher/acceptance/ApplicationAcceptanceTest.java
+++ b/bootstrap/src/test/java/gohigher/acceptance/ApplicationAcceptanceTest.java
@@ -15,7 +15,7 @@ import io.restassured.response.ValidatableResponse;
 @DisplayName("Application 인수테스트의")
 public class ApplicationAcceptanceTest extends AcceptanceTest {
 
-	@DisplayName("지원서를 작성 기능을 테스트한다")
+	@DisplayName("지원서를 작성하는 기능을 테스트한다")
 	@Test
 	void create_application() {
 		// given
@@ -37,5 +37,29 @@ public class ApplicationAcceptanceTest extends AcceptanceTest {
 			.body("data.companyName", equalTo(simpleApplicationRequest.getCompanyName()))
 			.body("data.currentProcessSchedule", equalTo(processRequest.getSchedule()))
 			.body("data.currentProcessDescription", equalTo(processRequest.getDescription()));
+	}
+
+	@DisplayName("지원서를 삭제하는 기능을 테스트한다")
+	@Test
+	void delete_application() {
+		// given
+		String accessToken = signUp("azpi@email.com", Provider.GOOGLE);
+		int applicationId = createApplication(accessToken);
+
+		// when
+		ValidatableResponse response = delete(accessToken, "/v1/applications/" + applicationId);
+
+		// then
+		response.statusCode(HttpStatus.NO_CONTENT.value());
+	}
+
+	private int createApplication(String accessToken) {
+		SimpleApplicationRequest request = new SimpleApplicationRequest(
+			"카카오", "개발자", "url",
+			new SimpleApplicationProcessRequest(ProcessType.TO_APPLY.name(), "지원 예정", null));
+
+		ValidatableResponse response = post(accessToken, "/v1/applications/simple", request);
+
+		return response.extract().path("data.id");
 	}
 }

--- a/core-application/src/main/java/gohigher/application/port/in/ApplicationCommandPort.java
+++ b/core-application/src/main/java/gohigher/application/port/in/ApplicationCommandPort.java
@@ -9,4 +9,6 @@ public interface ApplicationCommandPort {
 	void updateSimply(Long userId, Long applicationId, SimpleApplicationUpdateRequest request);
 
 	void updateCurrentProcess(Long userId, CurrentProcessUpdateRequest request);
+
+	void deleteApplication(Long userId, Long applicationId);
 }

--- a/core-application/src/main/java/gohigher/application/port/in/ApplicationProcessCommandPort.java
+++ b/core-application/src/main/java/gohigher/application/port/in/ApplicationProcessCommandPort.java
@@ -2,6 +2,6 @@ package gohigher.application.port.in;
 
 public interface ApplicationProcessCommandPort {
 
-	ApplicationProcessByProcessTypeResponse register(Long userId, long applicationId,
+	ApplicationProcessByProcessTypeResponse register(Long userId, Long applicationId,
 		UnscheduledProcessRequest request);
 }

--- a/core-application/src/main/java/gohigher/application/port/in/ApplicationProcessQueryPort.java
+++ b/core-application/src/main/java/gohigher/application/port/in/ApplicationProcessQueryPort.java
@@ -7,5 +7,5 @@ import gohigher.common.ProcessType;
 public interface ApplicationProcessQueryPort {
 
 	List<ApplicationProcessByProcessTypeResponse> findByApplicationIdAndProcessType(
-		Long userId, long applicationId, ProcessType processType);
+		Long userId, Long applicationId, ProcessType processType);
 }

--- a/core-application/src/main/java/gohigher/application/port/out/persistence/ApplicationPersistenceCommandPort.java
+++ b/core-application/src/main/java/gohigher/application/port/out/persistence/ApplicationPersistenceCommandPort.java
@@ -9,4 +9,6 @@ public interface ApplicationPersistenceCommandPort {
 	void updateCurrentProcessOrder(long id, long userId, long processId);
 
 	void updateSimply(Long processId, Application application);
+
+	void delete(long applicationId);
 }

--- a/core-application/src/main/java/gohigher/application/service/ApplicationCommandService.java
+++ b/core-application/src/main/java/gohigher/application/service/ApplicationCommandService.java
@@ -62,9 +62,7 @@ public class ApplicationCommandService implements ApplicationCommandPort {
 
 	@Override
 	public void deleteApplication(Long userId, Long applicationId) {
-		applicationPersistenceQueryPort.findByIdAndUserId(applicationId, userId)
-			.orElseThrow(() -> new GoHigherException(ApplicationErrorCode.APPLICATION_NOT_FOUND));
-
+		validateNotFound(userId, applicationId);
 		applicationPersistenceCommandPort.delete(applicationId);
 	}
 

--- a/core-application/src/main/java/gohigher/application/service/ApplicationCommandService.java
+++ b/core-application/src/main/java/gohigher/application/service/ApplicationCommandService.java
@@ -60,6 +60,14 @@ public class ApplicationCommandService implements ApplicationCommandPort {
 		applicationPersistenceCommandPort.updateCurrentProcessOrder(applicationId, userId, request.getProcessId());
 	}
 
+	@Override
+	public void deleteApplication(Long userId, Long applicationId) {
+		applicationPersistenceQueryPort.findByIdAndUserId(applicationId, userId)
+			.orElseThrow(() -> new GoHigherException(ApplicationErrorCode.APPLICATION_NOT_FOUND));
+
+		applicationPersistenceCommandPort.delete(applicationId);
+	}
+
 	private void validateNotFound(Long userId, Long applicationId) {
 		if (!applicationPersistenceQueryPort.existsByIdAndUserId(applicationId, userId)) {
 			throw new GoHigherException(APPLICATION_NOT_FOUND);

--- a/core-application/src/main/java/gohigher/application/service/ApplicationProcessCommandService.java
+++ b/core-application/src/main/java/gohigher/application/service/ApplicationProcessCommandService.java
@@ -27,7 +27,7 @@ public class ApplicationProcessCommandService implements ApplicationProcessComma
 	private final ApplicationProcessPersistenceQueryPort applicationProcessPersistenceQueryPort;
 
 	@Override
-	public ApplicationProcessByProcessTypeResponse register(Long userId, long applicationId,
+	public ApplicationProcessByProcessTypeResponse register(Long userId, Long applicationId,
 		UnscheduledProcessRequest request) {
 		validateAuthorizationOfUser(userId, applicationId);
 

--- a/core-application/src/main/java/gohigher/application/service/ApplicationProcessQueryService.java
+++ b/core-application/src/main/java/gohigher/application/service/ApplicationProcessQueryService.java
@@ -24,7 +24,7 @@ public class ApplicationProcessQueryService implements ApplicationProcessQueryPo
 
 	@Override
 	public List<ApplicationProcessByProcessTypeResponse> findByApplicationIdAndProcessType(Long userId,
-		long applicationId, ProcessType processType) {
+		Long applicationId, ProcessType processType) {
 		validateAuthorizationOfUser(userId, applicationId);
 		return applicationProcessPersistenceQueryPort.findByApplicationIdAndProcessType(applicationId, processType)
 			.stream()

--- a/core-application/src/test/java/gohigher/application/service/ApplicationCommandServiceTest.java
+++ b/core-application/src/test/java/gohigher/application/service/ApplicationCommandServiceTest.java
@@ -136,8 +136,8 @@ class ApplicationCommandServiceTest {
 				long applicationId = 1L;
 
 				// mocking
-				when(applicationPersistenceQueryPort.findByIdAndUserId(applicationId, notExistUserId))
-					.thenReturn(Optional.empty());
+				when(applicationPersistenceQueryPort.existsByIdAndUserId(applicationId, notExistUserId))
+					.thenReturn(false);
 
 				// when & then
 				assertThatThrownBy(() -> applicationCommandService.deleteApplication(notExistUserId, applicationId))
@@ -157,16 +157,14 @@ class ApplicationCommandServiceTest {
 				long notExistApplicationId = 0L;
 
 				// mocking
-				when(applicationPersistenceQueryPort.findByIdAndUserId(notExistApplicationId, userId))
-					.thenReturn(Optional.empty());
+				when(applicationPersistenceQueryPort.existsByIdAndUserId(notExistApplicationId, userId))
+					.thenReturn(false);
 
 				// when & then
 				assertThatThrownBy(() -> applicationCommandService.deleteApplication(userId, notExistApplicationId))
 					.hasMessage(APPLICATION_NOT_FOUND.getMessage());
 			}
 		}
-
-		// todo: 삭제된 지원서 <- 쿼리문 수정하고 나중에 추가
 
 		@DisplayName("지원서의 아이디로")
 		@Nested
@@ -180,8 +178,8 @@ class ApplicationCommandServiceTest {
 				long applicationId = 2L;
 
 				// mocking
-				when(applicationPersistenceQueryPort.findByIdAndUserId(applicationId, userId))
-					.thenReturn(Optional.of(NAVER_APPLICATION.toDomain()));
+				when(applicationPersistenceQueryPort.existsByIdAndUserId(applicationId, userId))
+					.thenReturn(true);
 				doNothing().when(applicationPersistenceCommandPort)
 						.delete(applicationId);
 

--- a/core-application/src/test/java/gohigher/application/service/ApplicationCommandServiceTest.java
+++ b/core-application/src/test/java/gohigher/application/service/ApplicationCommandServiceTest.java
@@ -1,8 +1,11 @@
 package gohigher.application.service;
 
 import static gohigher.application.ApplicationErrorCode.*;
+import static gohigher.application.ApplicationFixture.NAVER_APPLICATION;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
+
+import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -113,6 +116,78 @@ class ApplicationCommandServiceTest {
 				//then
 				verify(applicationPersistenceCommandPort)
 					.updateCurrentProcessOrder(request.getApplicationId(), userId, request.getProcessId());
+			}
+		}
+	}
+
+	@DisplayName("deleteApplication 메서드는")
+	@Nested
+	class Describe_deleteApplication {
+
+		@DisplayName("존재하지 않는 지원서의 아이디로 요청하면")
+		@Nested
+		class Context_with_not_exist_application_id {
+
+			@DisplayName("예외가 발생한다")
+			@Test
+			void it_throw_exception() {
+				// given
+				long notExistUserId = 0L;
+				long applicationId = 1L;
+
+				// mocking
+				when(applicationPersistenceQueryPort.findByIdAndUserId(applicationId, notExistUserId))
+					.thenReturn(Optional.empty());
+
+				// when & then
+				assertThatThrownBy(() -> applicationCommandService.deleteApplication(notExistUserId, applicationId))
+					.hasMessage(APPLICATION_NOT_FOUND.getMessage());
+			}
+		}
+
+		@DisplayName("다른 사용자가 작성한 지원서의 아이디로 요청하면")
+		@Nested
+		class Context_with_written_other_user {
+
+			@DisplayName("예외가 발생한다")
+			@Test
+			void it_throw_exception() {
+				// given
+				long userId = 1L;
+				long notExistApplicationId = 0L;
+
+				// mocking
+				when(applicationPersistenceQueryPort.findByIdAndUserId(notExistApplicationId, userId))
+					.thenReturn(Optional.empty());
+
+				// when & then
+				assertThatThrownBy(() -> applicationCommandService.deleteApplication(userId, notExistApplicationId))
+					.hasMessage(APPLICATION_NOT_FOUND.getMessage());
+			}
+		}
+
+		// todo: 삭제된 지원서 <- 쿼리문 수정하고 나중에 추가
+
+		@DisplayName("지원서의 아이디로")
+		@Nested
+		class Context_with_application_id {
+
+			@DisplayName("지원서를 삭제한다")
+			@Test
+			void it_delete_application() {
+				// given
+				long userId = 1L;
+				long applicationId = 2L;
+
+				// mocking
+				when(applicationPersistenceQueryPort.findByIdAndUserId(applicationId, userId))
+					.thenReturn(Optional.of(NAVER_APPLICATION.toDomain()));
+				doNothing().when(applicationPersistenceCommandPort)
+						.delete(applicationId);
+
+				// when & then
+				assertThatCode(() -> applicationCommandService.deleteApplication(userId, applicationId))
+					.doesNotThrowAnyException();
 			}
 		}
 	}

--- a/core-application/src/test/java/gohigher/application/service/ApplicationProcessCommandServiceTest.java
+++ b/core-application/src/test/java/gohigher/application/service/ApplicationProcessCommandServiceTest.java
@@ -13,6 +13,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import gohigher.application.ApplicationErrorCode;
 import gohigher.application.port.in.ApplicationProcessByProcessTypeResponse;
 import gohigher.application.port.in.UnscheduledProcessRequest;
 import gohigher.application.port.out.persistence.ApplicationPersistenceQueryPort;
@@ -68,6 +69,28 @@ class ApplicationProcessCommandServiceTest {
 
 				// then
 				assertThat(response.getDescription()).isEqualTo(interviewRequest.getDescription());
+			}
+		}
+
+		@DisplayName("지원서 아이디와 사용자 아이디가 일치하는 지원서가 없을 때")
+		@Nested
+		class Context_not_exist_application_with_application_id_and_user_id {
+
+			@DisplayName("예외가 발생한다")
+			@Test
+			void it_throw_exception() {
+				// given
+				long notExistUserId = 0L;
+				long notExistApplicationId = 0L;
+				UnscheduledProcessRequest request = mock(UnscheduledProcessRequest.class);
+
+				// mocking
+				when(applicationPersistenceQueryPort.existsByIdAndUserId(notExistApplicationId, notExistUserId))
+					.thenReturn(false);
+
+				// when & then
+				assertThatThrownBy(() -> applicationProcessCommandService.register(notExistUserId, notExistApplicationId, request))
+					.hasMessage(ApplicationErrorCode.APPLICATION_NOT_FOUND.getMessage());
 			}
 		}
 	}

--- a/in-adapter-api/src/main/java/gohigher/application/ApplicationCommandController.java
+++ b/in-adapter-api/src/main/java/gohigher/application/ApplicationCommandController.java
@@ -3,6 +3,7 @@ package gohigher.application;
 import java.net.URI;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -56,5 +57,11 @@ public class ApplicationCommandController implements ApplicationCommandControlle
 		@RequestBody @Valid SimpleApplicationUpdateRequest request) {
 		applicationCommandPort.updateSimply(userId, applicationId, request);
 		return ResponseEntity.ok(GohigherResponse.success(null));
+	}
+
+	@DeleteMapping("/{applicationId}")
+	public ResponseEntity<GohigherResponse<Void>> deleteApplication(@Login Long userId, @PathVariable Long applicationId) {
+		applicationCommandPort.deleteApplication(userId, applicationId);
+		return ResponseEntity.noContent().build();
 	}
 }

--- a/in-adapter-api/src/main/java/gohigher/application/ApplicationCommandControllerDocs.java
+++ b/in-adapter-api/src/main/java/gohigher/application/ApplicationCommandControllerDocs.java
@@ -257,4 +257,22 @@ public interface ApplicationCommandControllerDocs {
 				}))})
 	ResponseEntity<GohigherResponse<Void>> updateSimply(@Parameter(hidden = true) Long userId, Long applicationId,
 		@RequestBody SimpleApplicationUpdateRequest request);
+
+	@Operation(summary = "지원서 삭제")
+	@ApiResponses(
+		value = {
+			@ApiResponse(responseCode = "200", description = "지원서 삭제 성공"),
+			@ApiResponse(responseCode = "404", description = "지원서 삭제 실패", content = @Content(
+				examples = {@ExampleObject(name = "존재하지 않는 지원서", value = """
+					{
+					"success": false,
+					"error": {
+						"code": "APPLICATION_001",
+						"message": "존재하지 않는 지원서입니다."
+					},
+					"data": null
+					}
+					""")
+				}))})
+	ResponseEntity<GohigherResponse<Void>> deleteApplication(@Parameter(hidden = true) Long userId, Long applicationId);
 }

--- a/in-adapter-api/src/main/java/gohigher/application/ApplicationProcessCommandController.java
+++ b/in-adapter-api/src/main/java/gohigher/application/ApplicationProcessCommandController.java
@@ -22,7 +22,7 @@ public class ApplicationProcessCommandController implements ApplicationProcessCo
 
 	@PostMapping("/v1/applications/{applicationId}/processes")
 	public ResponseEntity<GohigherResponse<ApplicationProcessByProcessTypeResponse>> registerApplicationProcess(
-		@Login Long userId, @PathVariable long applicationId,
+		@Login Long userId, @PathVariable Long applicationId,
 		@Valid @RequestBody UnscheduledProcessRequest request) {
 		ApplicationProcessByProcessTypeResponse response = applicationProcessCommandPort.register(userId, applicationId,
 			request);

--- a/in-adapter-api/src/main/java/gohigher/application/ApplicationProcessCommandControllerDocs.java
+++ b/in-adapter-api/src/main/java/gohigher/application/ApplicationProcessCommandControllerDocs.java
@@ -58,6 +58,6 @@ public interface ApplicationProcessCommandControllerDocs {
 			}))
 	})
 	ResponseEntity<GohigherResponse<ApplicationProcessByProcessTypeResponse>> registerApplicationProcess(
-		@Parameter(hidden = true) Long userId, long applicationId,
+		@Parameter(hidden = true) Long userId, Long applicationId,
 		@RequestBody UnscheduledProcessRequest request);
 }

--- a/in-adapter-api/src/main/java/gohigher/application/ApplicationProcessQueryController.java
+++ b/in-adapter-api/src/main/java/gohigher/application/ApplicationProcessQueryController.java
@@ -23,7 +23,7 @@ public class ApplicationProcessQueryController implements ApplicationProcessQuer
 
 	@GetMapping("/v1/applications/{applicationId}/processes")
 	public ResponseEntity<GohigherResponse<List<ApplicationProcessByProcessTypeResponse>>> getApplicationProcessesByApplicationIdAndType(
-		@Login Long userId, @PathVariable long applicationId, @RequestParam ProcessType processType) {
+		@Login Long userId, @PathVariable Long applicationId, @RequestParam ProcessType processType) {
 		List<ApplicationProcessByProcessTypeResponse> response =
 			applicationProcessQueryPort.findByApplicationIdAndProcessType(userId, applicationId, processType);
 		return ResponseEntity.ok(GohigherResponse.success(response));

--- a/in-adapter-api/src/main/java/gohigher/application/ApplicationProcessQueryControllerDocs.java
+++ b/in-adapter-api/src/main/java/gohigher/application/ApplicationProcessQueryControllerDocs.java
@@ -62,5 +62,5 @@ public interface ApplicationProcessQueryControllerDocs {
 		}
 	)
 	ResponseEntity<GohigherResponse<List<ApplicationProcessByProcessTypeResponse>>> getApplicationProcessesByApplicationIdAndType(
-		@Parameter(hidden = true) Long userId, long applicationId, ProcessType processType);
+		@Parameter(hidden = true) Long userId, Long applicationId, ProcessType processType);
 }

--- a/out-adapter-persistence-jpa/src/main/java/gohigher/application/ApplicationPersistenceCommandAdapter.java
+++ b/out-adapter-persistence-jpa/src/main/java/gohigher/application/ApplicationPersistenceCommandAdapter.java
@@ -70,4 +70,12 @@ public class ApplicationPersistenceCommandAdapter implements ApplicationPersiste
 
 		applicationProcessJpaEntity.update(application.getProcessById(processId));
 	}
+
+	@Override
+	public void delete(long id) {
+		ApplicationJpaEntity applicationJpaEntity = applicationRepository.findById(id)
+			.orElseThrow(() -> new GoHigherException(APPLICATION_NOT_FOUND));
+
+		applicationJpaEntity.delete();
+	}
 }

--- a/out-adapter-persistence-jpa/src/main/java/gohigher/application/entity/ApplicationJpaEntity.java
+++ b/out-adapter-persistence-jpa/src/main/java/gohigher/application/entity/ApplicationJpaEntity.java
@@ -94,7 +94,7 @@ public class ApplicationJpaEntity {
 		processes.add(process);
 	}
 
-	public void changeToDelete() {
+	public void delete() {
 		this.deleted = true;
 	}
 

--- a/out-adapter-persistence-jpa/src/test/java/gohigher/application/ApplicationPersistenceCommandAdapterTest.java
+++ b/out-adapter-persistence-jpa/src/test/java/gohigher/application/ApplicationPersistenceCommandAdapterTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -181,6 +182,40 @@ class ApplicationPersistenceCommandAdapterTest {
 							tuple(secondProcess.getType(), scheduleToUpdate)
 						)
 				);
+			}
+		}
+	}
+
+	@DisplayName("delete 메서드는")
+	@Nested
+	class Describe_delete {
+
+		@DisplayName("지원서 아이디로")
+		@Nested
+		class Context_with_application_id {
+
+			@DisplayName("지원서를 삭제한다")
+			@Test
+			void it_delete_application() {
+				// given
+				ApplicationJpaEntity applicationJpaEntity = applicationRepository.save(ApplicationJpaEntity.of(application, USER_ID));
+
+				ApplicationProcessJpaEntity processJpaEntity = applicationProcessRepository.save(
+					ApplicationProcessJpaEntity.of(applicationJpaEntity, firstProcess, true));
+				applicationJpaEntity.addProcess(processJpaEntity);
+
+				Application application = applicationJpaEntity.toDomain();
+
+				// when
+				applicationPersistenceCommandAdapter.delete(application.getId());
+
+				// then
+				Optional<ApplicationJpaEntity> deletedApplication = applicationRepository.findById(application.getId());
+				assertThat(deletedApplication).isPresent();
+
+				ApplicationJpaEntity actual = deletedApplication.get();
+
+				assertThat(actual.isDeleted()).isTrue();
 			}
 		}
 	}

--- a/out-adapter-persistence-jpa/src/test/java/gohigher/application/entity/ApplicationRepositoryTest.java
+++ b/out-adapter-persistence-jpa/src/test/java/gohigher/application/entity/ApplicationRepositoryTest.java
@@ -23,7 +23,6 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 import gohigher.application.Application;
@@ -89,7 +88,7 @@ class ApplicationRepositoryTest {
 				Application naverApplication = NAVER_APPLICATION.toDomain();
 				naverApplicationEntity = saveApplicationAndProcesses(userId, naverApplication);
 
-				naverApplicationEntity.changeToDelete();
+				naverApplicationEntity.delete();
 			}
 
 			@DisplayName("비어있는 결과를 반환한다.")


### PR DESCRIPTION
## 작업 내용
- 지원서 삭제 기능 구현
- 지원서 조회 시 삭제된 지원서 예외 처리 확인
- 삭제 기능 테스트 코드 추가

## 고려사항
- 지원서 조회 시 삭제 여부에 따른 조건 처리는 DB 계층에서 처리
    - 지원서 조회 시 애초에 삭제되지 않는 데이터만 조회 (하도록 쿼리문 수정을 하려 했으나 이미 반영되어 있음)
    - 클라이언트에게 존재하지 않는 지원서와 삭제된 지원서의 여부를 굳이 나누어서 보여줄 필요가 없어 보임
    - soft delete 의 목적은 데이터를 쌓아두기 위한 것이기 때문에 서비스 상에서 관련 처리를 매번 추가하는 것은 불필요하다 판단
        - deleted 필드 조건 없이 조회할 경우 조회, 수정, 삭제 시 삭제 여부 확인 필요
- 현재 서비스 상에서 삭제 여부에 따른 조회 등의 기능이 없기 때문에 삭제 여부 필드는 엔티티에만 추가함 (도메인 X)
- 지원서 관련 ‘목록’ 조회 시에는 삭제된 지원서 제외하고 조회
    - 예외는 발생하지 않음


resolve #164 
