### PR TITLE
[REFACTOR] 토큰 리프레시 API

### DIFF
--- a/bootstrap/src/test/java/gohigher/acceptance/AcceptanceTest.java
+++ b/bootstrap/src/test/java/gohigher/acceptance/AcceptanceTest.java
@@ -60,7 +60,7 @@ public class AcceptanceTest {
 	void assignDesiredPositions(String accessToken) {
 		DesiredPositionRequest desiredPositionRequest = new DesiredPositionRequest(
 			List.of(developer.getId(), designer.getId()));
-		post(accessToken, "v1/desired-positions", desiredPositionRequest);
+		post(accessToken, "/v1/desired-positions", desiredPositionRequest);
 	}
 
 	ValidatableResponse post(String accessToken, String uri, Object requestBody) {

--- a/core-application/src/main/java/gohigher/user/port/in/TokenCommandPort.java
+++ b/core-application/src/main/java/gohigher/user/port/in/TokenCommandPort.java
@@ -6,5 +6,5 @@ public interface TokenCommandPort {
 
 	void saveRefreshToken(Long userId, String refreshToken);
 
-	RefreshedTokenResponse refreshToken(Long userId, Date now, String refreshToken);
+	RefreshedTokenResponse refreshToken(Date now, String refreshToken);
 }

--- a/core-application/src/test/java/gohigher/user/service/TokenCommandServiceTest.java
+++ b/core-application/src/test/java/gohigher/user/service/TokenCommandServiceTest.java
@@ -63,7 +63,7 @@ class TokenCommandServiceTest {
 				doNothing().when(refreshTokenPersistenceCommandPort).update(anyLong(), anyString());
 
 				// then
-				assertThat(tokenCommandService.refreshToken(userId, now, previousRefreshToken)).isNotNull();
+				assertThat(tokenCommandService.refreshToken(now, previousRefreshToken)).isNotNull();
 			}
 
 			@DisplayName("유효성 확인 후, 이미 사용한 토큰이면 예외를 발생한다.")
@@ -79,7 +79,7 @@ class TokenCommandServiceTest {
 
 				// then
 				String anotherToken = jwtProvider.createToken(userId, now, TokenType.REFRESH);
-				assertThatThrownBy(() -> tokenCommandService.refreshToken(userId, now, anotherToken))
+				assertThatThrownBy(() -> tokenCommandService.refreshToken(now, anotherToken))
 					.isInstanceOf(GoHigherException.class)
 					.hasMessage(AuthErrorCode.USED_REFRESH_TOKEN.getMessage());
 			}

--- a/in-adapter-api/src/main/java/gohigher/user/TokenCommandController.java
+++ b/in-adapter-api/src/main/java/gohigher/user/TokenCommandController.java
@@ -9,7 +9,6 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import gohigher.controller.response.GohigherResponse;
-import gohigher.support.auth.Login;
 import gohigher.support.auth.RefreshTokenCookieProvider;
 import gohigher.user.port.in.RefreshedTokenResponse;
 import gohigher.user.port.in.TokenCommandPort;
@@ -27,10 +26,10 @@ public class TokenCommandController implements TokenCommandControllerDocs {
 
 	@PatchMapping("/tokens/mine")
 	public ResponseEntity<GohigherResponse<TokenResponse>> reissueRefreshTokens(HttpServletRequest request,
-		HttpServletResponse response, @Login Long userId) {
+		HttpServletResponse response) {
 		String refreshToken = refreshTokenCookieProvider.extractToken(request.getCookies());
 		Date now = new Date();
-		RefreshedTokenResponse refreshedTokenResponse = tokenCommandPort.refreshToken(userId, now, refreshToken);
+		RefreshedTokenResponse refreshedTokenResponse = tokenCommandPort.refreshToken(now, refreshToken);
 		TokenResponse tokenResponse = new TokenResponse(refreshedTokenResponse.getAccessToken());
 		addRefreshTokenCookie(response, refreshedTokenResponse.getRefreshToken());
 		return ResponseEntity.ok(GohigherResponse.success(tokenResponse));

--- a/in-adapter-api/src/main/java/gohigher/user/TokenCommandControllerDocs.java
+++ b/in-adapter-api/src/main/java/gohigher/user/TokenCommandControllerDocs.java
@@ -5,7 +5,6 @@ import org.springframework.http.ResponseEntity;
 import gohigher.controller.response.GohigherResponse;
 import gohigher.user.port.in.TokenResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -74,5 +73,5 @@ public interface TokenCommandControllerDocs {
 		)),
 	})
 	ResponseEntity<GohigherResponse<TokenResponse>> reissueRefreshTokens(HttpServletRequest request,
-		HttpServletResponse response, @Parameter(hidden = true) Long userId);
+		HttpServletResponse response);
 }


### PR DESCRIPTION
## 작업 내용
- 기존의 로직에서는 토큰 리프레시 요청 당시 엑세스 토큰을 동행시킵니다. 그래서 엑세스 토큰을 파싱하는 과정에서 만료 Exception이 발생해 정상적인 요청이 이루어지지 않습니다. 
- 따라서 리프레시 토큰만으로 토큰을 리프레시하는 방식으로 변경합니다.

resolve #180
