### PR TITLE
[FIX] Security의 CORS 문제 해결

### DIFF
--- a/security/src/main/java/gohigher/config/SpringSecurityConfig.java
+++ b/security/src/main/java/gohigher/config/SpringSecurityConfig.java
@@ -2,16 +2,22 @@ package gohigher.config;
 
 import static org.springframework.security.config.Customizer.*;
 
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.CorsUtils;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import gohigher.jwt.JwtAuthFilter;
 import gohigher.jwt.JwtExceptionFilter;
@@ -24,6 +30,9 @@ import gohigher.oauth2.handler.LogoutHandler;
 @EnableWebSecurity
 public class SpringSecurityConfig {
 
+	private final List<String> allowedMethods = List.of("GET", "HEAD", "POST", "PUT", "DELETE", "TRACE", "OPTIONS",
+		"PATCH");
+
 	private final OauthUserService oauthUserService;
 	private final JwtAuthFilter jwtAuthFilter;
 	private final JwtExceptionFilter jwtExceptionFilter;
@@ -32,6 +41,7 @@ public class SpringSecurityConfig {
 	private final LogoutHandler logoutHandler;
 	private final String tokenRequestUri;
 	private final String tokenCookieKey;
+	private final String allowedOrigin;
 
 	public SpringSecurityConfig(OauthUserService oauthUserService, JwtAuthFilter jwtAuthFilter,
 		JwtExceptionFilter jwtExceptionFilter,
@@ -39,7 +49,8 @@ public class SpringSecurityConfig {
 		AuthenticationFailureHandler oAuth2LoginFailureHandler,
 		LogoutHandler logoutHandler,
 		@Value("${token.request.uri}") String tokenRequestUri,
-		@Value("${token.cookie.key}") String tokenCookieKey) {
+		@Value("${token.cookie.key}") String tokenCookieKey,
+		@Value("${cors-config.allowed-origin}") String allowedOrigin) {
 		this.oauthUserService = oauthUserService;
 		this.jwtAuthFilter = jwtAuthFilter;
 		this.jwtExceptionFilter = jwtExceptionFilter;
@@ -48,11 +59,13 @@ public class SpringSecurityConfig {
 		this.logoutHandler = logoutHandler;
 		this.tokenRequestUri = tokenRequestUri;
 		this.tokenCookieKey = tokenCookieKey;
+		this.allowedOrigin = allowedOrigin;
 	}
 
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-		http.csrf(CsrfConfigurer::disable)
+		http.cors(cors -> cors.configurationSource(corsConfigurationSource()))
+			.csrf(CsrfConfigurer::disable)
 			.sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 			.authorizeHttpRequests(auth ->
 				auth.requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
@@ -69,12 +82,25 @@ public class SpringSecurityConfig {
 			.successHandler(oAuth2LoginSuccessHandler)
 			.failureHandler(oAuth2LoginFailureHandler));
 
-		http.logout(logout -> logout.logoutUrl("/logout")
+		http.logout(logout -> logout.logoutUrl("/tokens/logout")
 			.logoutSuccessHandler(logoutHandler)
 			.deleteCookies(tokenCookieKey));
 
 		return http.addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
 			.addFilterBefore(jwtExceptionFilter, JwtAuthFilter.class)
 			.build();
+	}
+
+	@Bean
+	public CorsConfigurationSource corsConfigurationSource() {
+		CorsConfiguration configuration = new CorsConfiguration();
+		configuration.setAllowedOrigins(List.of(allowedOrigin));
+		configuration.setAllowedMethods(allowedMethods);
+		configuration.setAllowCredentials(true);
+		configuration.addExposedHeader(HttpHeaders.LOCATION);
+
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", configuration);
+		return source;
 	}
 }

--- a/security/src/main/java/gohigher/oauth2/handler/LogoutHandler.java
+++ b/security/src/main/java/gohigher/oauth2/handler/LogoutHandler.java
@@ -1,38 +1,19 @@
 package gohigher.oauth2.handler;
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.web.authentication.AbstractAuthenticationTargetUrlRequestHandler;
 import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
 import org.springframework.stereotype.Component;
-import org.springframework.web.util.UriComponentsBuilder;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 @Component
-public class LogoutHandler extends AbstractAuthenticationTargetUrlRequestHandler implements LogoutSuccessHandler {
-
-	private final String redirectUri;
-	private final String logoutRedirectUri;
-
-	public LogoutHandler(@Value("${oauth2.success.redirect_uri}") String redirectUri,
-		@Value("${logout.redirect.uri}") String logoutRedirectUri) {
-		this.redirectUri = redirectUri;
-		this.logoutRedirectUri = logoutRedirectUri;
-	}
+public class LogoutHandler implements LogoutSuccessHandler {
 
 	@Override
 	public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response,
-		Authentication authentication) throws IOException {
-		String targetUrl = UriComponentsBuilder.fromUriString(redirectUri + logoutRedirectUri)
-			.build()
-			.encode(StandardCharsets.UTF_8)
-			.toUriString();
-
-		getRedirectStrategy().sendRedirect(request, response, targetUrl);
+		Authentication authentication) {
+		response.setStatus(HttpStatus.NO_CONTENT.value());
 	}
 }

--- a/security/src/main/resources/auth/application.yml
+++ b/security/src/main/resources/auth/application.yml
@@ -25,7 +25,3 @@ token:
     uri: '/tokens'
   cookie:
     key: 'refresh-token'
-
-logout:
-  redirect:
-    uri: '/logout'


### PR DESCRIPTION
## 작업 내용
기존에 Spring MVC의 AuthConfig를 Security에서도 사용하고 있었으나, 해당 방식은 MVC의 Handler에서 다루는 uri만 적용된다고 합니다. 더 자세히 알아봐야겠지만 /logout의 경우 실제로 따로 Handler에서 다루지 않는 API이고 AuthConfig가 적용되지 않는 사실을 발견했습니다. 따라서 Security에 추가로 CORS 처리를 하였습니다.

resolve #184 
