### PR TITLE
[FIX] 로그아웃 API

### DIFF
--- a/core-application/src/main/java/gohigher/user/port/in/TokenCommandPort.java
+++ b/core-application/src/main/java/gohigher/user/port/in/TokenCommandPort.java
@@ -7,4 +7,6 @@ public interface TokenCommandPort {
 	void saveRefreshToken(Long userId, String refreshToken);
 
 	RefreshedTokenResponse refreshToken(Date now, String refreshToken);
+
+	void deleteRefreshToken(Long loginId);
 }

--- a/core-application/src/main/java/gohigher/user/service/TokenCommandService.java
+++ b/core-application/src/main/java/gohigher/user/service/TokenCommandService.java
@@ -51,6 +51,11 @@ public class TokenCommandService implements TokenCommandPort {
 		return new RefreshedTokenResponse(jwtProvider.createToken(userId, now, TokenType.ACCESS), newRefreshToken);
 	}
 
+	@Override
+	public void deleteRefreshToken(Long loginId) {
+		refreshTokenPersistenceCommandport.delete(loginId);
+	}
+
 	private Long parseToken(String refreshToken) {
 		try {
 			return jwtProvider.getPayload(refreshToken);

--- a/in-adapter-api/src/main/java/gohigher/support/auth/RefreshTokenCookieProvider.java
+++ b/in-adapter-api/src/main/java/gohigher/support/auth/RefreshTokenCookieProvider.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.server.Cookie.SameSite;
 import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseCookie.ResponseCookieBuilder;
 import org.springframework.stereotype.Component;
 
 import gohigher.global.exception.GoHigherException;
@@ -33,7 +34,7 @@ public class RefreshTokenCookieProvider {
 			.build();
 	}
 
-	private ResponseCookie.ResponseCookieBuilder createTokenCookieBuilder(String value) {
+	private ResponseCookieBuilder createTokenCookieBuilder(String value) {
 		return ResponseCookie.from(refreshTokenKey, value)
 			.httpOnly(true)
 			.secure(true)
@@ -48,6 +49,12 @@ public class RefreshTokenCookieProvider {
 			.findAny()
 			.orElseThrow(() -> new GoHigherException(AuthErrorCode.EMPTY_REFRESH_TOKEN_COOKIE))
 			.getValue();
+	}
+
+	public ResponseCookie createInvalidCookie() {
+		return createTokenCookieBuilder("")
+			.maxAge(Duration.ofMillis(0))
+			.build();
 	}
 
 	private void validateCookiesNotEmpty(Cookie[] cookies) {

--- a/security/src/main/java/gohigher/config/SpringSecurityConfig.java
+++ b/security/src/main/java/gohigher/config/SpringSecurityConfig.java
@@ -31,15 +31,13 @@ public class SpringSecurityConfig {
 	private final AuthenticationFailureHandler oAuth2LoginFailureHandler;
 	private final LogoutHandler logoutHandler;
 	private final String tokenRequestUri;
-	private final String tokenCookieKey;
 
 	public SpringSecurityConfig(OauthUserService oauthUserService, JwtAuthFilter jwtAuthFilter,
 		JwtExceptionFilter jwtExceptionFilter,
 		AuthenticationSuccessHandler oAuth2LoginSuccessHandler,
 		AuthenticationFailureHandler oAuth2LoginFailureHandler,
 		LogoutHandler logoutHandler,
-		@Value("${token.request.uri}") String tokenRequestUri,
-		@Value("${token.cookie.key}") String tokenCookieKey) {
+		@Value("${token.request.uri}") String tokenRequestUri) {
 		this.oauthUserService = oauthUserService;
 		this.jwtAuthFilter = jwtAuthFilter;
 		this.jwtExceptionFilter = jwtExceptionFilter;
@@ -47,7 +45,6 @@ public class SpringSecurityConfig {
 		this.oAuth2LoginFailureHandler = oAuth2LoginFailureHandler;
 		this.logoutHandler = logoutHandler;
 		this.tokenRequestUri = tokenRequestUri;
-		this.tokenCookieKey = tokenCookieKey;
 	}
 
 	@Bean
@@ -70,7 +67,7 @@ public class SpringSecurityConfig {
 			.successHandler(oAuth2LoginSuccessHandler)
 			.failureHandler(oAuth2LoginFailureHandler));
 
-		http.logout(logout -> logout.logoutUrl("/tokens/logout")
+		http.logout(logout -> logout.logoutUrl(tokenRequestUri + "/logout")
 			.logoutSuccessHandler(logoutHandler));
 
 		return http.addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)

--- a/security/src/main/java/gohigher/config/SpringSecurityConfig.java
+++ b/security/src/main/java/gohigher/config/SpringSecurityConfig.java
@@ -7,17 +7,13 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpHeaders;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.CorsUtils;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import gohigher.jwt.JwtAuthFilter;
 import gohigher.jwt.JwtExceptionFilter;
@@ -64,7 +60,7 @@ public class SpringSecurityConfig {
 
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-		http.cors(cors -> cors.configurationSource(corsConfigurationSource()))
+		http.cors(withDefaults())
 			.csrf(CsrfConfigurer::disable)
 			.sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 			.authorizeHttpRequests(auth ->
@@ -89,18 +85,5 @@ public class SpringSecurityConfig {
 		return http.addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
 			.addFilterBefore(jwtExceptionFilter, JwtAuthFilter.class)
 			.build();
-	}
-
-	@Bean
-	public CorsConfigurationSource corsConfigurationSource() {
-		CorsConfiguration configuration = new CorsConfiguration();
-		configuration.setAllowedOrigins(List.of(allowedOrigin));
-		configuration.setAllowedMethods(allowedMethods);
-		configuration.setAllowCredentials(true);
-		configuration.addExposedHeader(HttpHeaders.LOCATION);
-
-		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-		source.registerCorsConfiguration("/**", configuration);
-		return source;
 	}
 }

--- a/security/src/main/java/gohigher/config/SpringSecurityConfig.java
+++ b/security/src/main/java/gohigher/config/SpringSecurityConfig.java
@@ -2,8 +2,6 @@ package gohigher.config;
 
 import static org.springframework.security.config.Customizer.*;
 
-import java.util.List;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -26,9 +24,6 @@ import gohigher.oauth2.handler.LogoutHandler;
 @EnableWebSecurity
 public class SpringSecurityConfig {
 
-	private final List<String> allowedMethods = List.of("GET", "HEAD", "POST", "PUT", "DELETE", "TRACE", "OPTIONS",
-		"PATCH");
-
 	private final OauthUserService oauthUserService;
 	private final JwtAuthFilter jwtAuthFilter;
 	private final JwtExceptionFilter jwtExceptionFilter;
@@ -37,7 +32,6 @@ public class SpringSecurityConfig {
 	private final LogoutHandler logoutHandler;
 	private final String tokenRequestUri;
 	private final String tokenCookieKey;
-	private final String allowedOrigin;
 
 	public SpringSecurityConfig(OauthUserService oauthUserService, JwtAuthFilter jwtAuthFilter,
 		JwtExceptionFilter jwtExceptionFilter,
@@ -45,8 +39,7 @@ public class SpringSecurityConfig {
 		AuthenticationFailureHandler oAuth2LoginFailureHandler,
 		LogoutHandler logoutHandler,
 		@Value("${token.request.uri}") String tokenRequestUri,
-		@Value("${token.cookie.key}") String tokenCookieKey,
-		@Value("${cors-config.allowed-origin}") String allowedOrigin) {
+		@Value("${token.cookie.key}") String tokenCookieKey) {
 		this.oauthUserService = oauthUserService;
 		this.jwtAuthFilter = jwtAuthFilter;
 		this.jwtExceptionFilter = jwtExceptionFilter;
@@ -55,7 +48,6 @@ public class SpringSecurityConfig {
 		this.logoutHandler = logoutHandler;
 		this.tokenRequestUri = tokenRequestUri;
 		this.tokenCookieKey = tokenCookieKey;
-		this.allowedOrigin = allowedOrigin;
 	}
 
 	@Bean
@@ -79,8 +71,7 @@ public class SpringSecurityConfig {
 			.failureHandler(oAuth2LoginFailureHandler));
 
 		http.logout(logout -> logout.logoutUrl("/tokens/logout")
-			.logoutSuccessHandler(logoutHandler)
-			.deleteCookies(tokenCookieKey));
+			.logoutSuccessHandler(logoutHandler));
 
 		return http.addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
 			.addFilterBefore(jwtExceptionFilter, JwtAuthFilter.class)

--- a/security/src/main/java/gohigher/oauth2/handler/LogoutHandler.java
+++ b/security/src/main/java/gohigher/oauth2/handler/LogoutHandler.java
@@ -1,19 +1,37 @@
 package gohigher.oauth2.handler;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
 import org.springframework.stereotype.Component;
 
+import gohigher.support.auth.JwtProvider;
+import gohigher.support.auth.RefreshTokenCookieProvider;
+import gohigher.user.port.in.TokenCommandPort;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 
 @Component
+@RequiredArgsConstructor
 public class LogoutHandler implements LogoutSuccessHandler {
+
+	private final RefreshTokenCookieProvider refreshTokenCookieProvider;
+	private final JwtProvider jwtProvider;
+	private final TokenCommandPort tokenCommandPort;
 
 	@Override
 	public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response,
 		Authentication authentication) {
+		String refreshToken = refreshTokenCookieProvider.extractToken(request.getCookies());
+		Long loginId = jwtProvider.getPayload(refreshToken);
+		tokenCommandPort.deleteRefreshToken(loginId);
+
+		ResponseCookie refreshCookie = refreshTokenCookieProvider.createInvalidCookie();
+		response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
+
 		response.setStatus(HttpStatus.NO_CONTENT.value());
 	}
 }


### PR DESCRIPTION
## 작업 내용
- CORS 처리가 MVC와 Security에서 충돌이 나는 것 같아 MVC에 일임하였습니다.
- 로그아웃 시 리프레시 토큰의 path로 인해 security가 제공하는 deleteCookie을 사용할시에 제대로 지워지지 않았습니다. 따라서 LogoutHandler에서 쿠키 삭제 로직을 만드는 방식으로 해결했습니다.

resolve #188 
